### PR TITLE
Add REVIEW.md for Claude code reviews

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,27 @@
+name: Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          review_comment_prefix: "**Claude Review:**"
+          direct_prompt: |
+            Review this PR following the guidelines in REVIEW.md and CLAUDE.md.
+            Focus on accessibility, security, and test coverage.
+            Be concise — flag real issues, skip style nitpicks.

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -16,12 +16,12 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          review_comment_prefix: "**Claude Review:**"
-          direct_prompt: |
+          prompt: |
             Review this PR following the guidelines in REVIEW.md and CLAUDE.md.
             Focus on accessibility, security, and test coverage.
             Be concise — flag real issues, skip style nitpicks.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,20 +23,16 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-
       - uses: aws-actions/setup-sam@v2
         with:
           use-installer: true
-
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::380610849750:role/plato-deploy
           aws-region: us-east-2
-
       - run: cd client && npm ci && npm run build
       - run: cd server && sam build
       - run: |

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,24 @@
+# Code Review Guidelines
+
+Review instructions for the Claude GitHub App. These apply in addition to CLAUDE.md.
+
+## Critical — always flag
+
+- **Accessibility:** Every interactive element (button, input, link, toggle) must be keyboard-operable and have an accessible name (aria-label, role, etc.). Missing accessibility is a blocking issue.
+- **Security:** No command injection, XSS, SQL injection, or secrets in code. Auth tokens only in `plato_auth` localStorage key.
+- **Tests:** Server-side changes to routes or lib should have corresponding tests in `server/tests/`. Check that `npm test` would still pass.
+- **Content change management:** Changes to files in `client/prompts/` or `client/data/` will surface as pending updates for admins on existing installs. This is expected — just note it in the review.
+
+## Important — flag as suggestions
+
+- **Docs:** Changes that affect architecture, features, or dev workflow should update CLAUDE.md, README.md, or CONTRIBUTING.md.
+- **Admin pages** (`/plato/*`) must not use classroom branding (no BrandingProvider, no usePublicBranding).
+- **Classroom pages** must use BrandingProvider context.
+- **Auth pages** (login, signup, forgot-password, reset-password) must use usePublicBranding hook.
+- **API consistency:** User group responses use `{ userGroups: [...] }`. Sync data uses optimistic locking via version field.
+
+## Skip — do not flag
+
+- Files in `dist/`, `.aws-sam/`, `node_modules/`
+- Bundle size changes
+- Minor style preferences (semicolons, trailing commas) — the project has no linter enforcing these


### PR DESCRIPTION
## Summary
- Adds `REVIEW.md` with review-specific guidelines for the Claude GitHub App
- Critical rules: accessibility, security, tests
- Suggested rules: docs updates, branding context usage, API consistency
- Skip rules: dist, .aws-sam, style preferences

This is also a good test of the Claude review — it should review this PR!

🤖 Generated with [Claude Code](https://claude.com/claude-code)