### PR TITLE
Fix React hooks order error on admin users page

### DIFF
--- a/client/src/pages/admin/AdminUsers.jsx
+++ b/client/src/pages/admin/AdminUsers.jsx
@@ -370,6 +370,13 @@ export default function AdminUsers() {
     return items;
   }, [users, pendingInvites]);
 
+  const filterCounts = useMemo(() => ({
+    all: combinedList.length,
+    active: combinedList.filter(i => i._type === 'user' && i.role === 'user').length,
+    admins: combinedList.filter(i => i._type === 'user' && i.role === 'admin').length,
+    invited: combinedList.filter(i => i._type === 'invite').length,
+  }), [combinedList]);
+
   const filteredList = useMemo(() => {
     let list = combinedList;
 
@@ -462,13 +469,6 @@ export default function AdminUsers() {
       </div>
     );
   }
-
-  const filterCounts = useMemo(() => ({
-    all: combinedList.length,
-    active: combinedList.filter(i => i._type === 'user' && i.role === 'user').length,
-    admins: combinedList.filter(i => i._type === 'user' && i.role === 'admin').length,
-    invited: combinedList.filter(i => i._type === 'invite').length,
-  }), [combinedList]);
 
   const filterButtons = [
     { key: 'all', label: 'All' },


### PR DESCRIPTION
## Summary
- Moves `filterCounts` useMemo before the conditional early return
- Fixes React error #310: "Rendered more hooks than during the previous render"

## Test plan
- [ ] Load /plato/users — no console errors
- [ ] Filter tabs show correct counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)