### PR TITLE
Fix metadata tags leaking into chat stream

### DIFF
--- a/client/src/lib/courseEngine.js
+++ b/client/src/lib/courseEngine.js
@@ -63,12 +63,15 @@ function parseCoachResponse(raw) {
 function cleanStream(onStream) {
   if (!onStream) return () => {};
   return (partial) => {
-    const cleaned = partial
+    // Strip any fully-formed tags
+    let cleaned = partial
       .replace(PROGRESS_REGEX, '')
       .replace(KB_UPDATE_REGEX, '')
-      .replace(PROFILE_UPDATE_REGEX, '')
-      .trim();
-    onStream(cleaned);
+      .replace(PROFILE_UPDATE_REGEX, '');
+    // Truncate at any partial tag still being streamed (tags always come at the end)
+    const tagStart = cleaned.search(/\n?\[(?:PROGRESS|KB_UPDATE|PROFILE_UPDATE)[:\s]/);
+    if (tagStart !== -1) cleaned = cleaned.slice(0, tagStart);
+    onStream(cleaned.trim());
   };
 }
 


### PR DESCRIPTION
## Summary
- `[KB_UPDATE: ...]` and `[PROFILE_UPDATE: ...]` tags were visible to learners during streaming
- Root cause: tags arrive in chunks, so regex can't match incomplete tags mid-stream
- Fix: truncate displayed text at any partial tag start since tags always come at the end of responses
- Full response parsing after stream completes is unaffected

## Test plan
- [ ] Start a course conversation, send several messages
- [ ] Verify no `[KB_UPDATE`, `[PROGRESS`, or `[PROFILE_UPDATE` text appears in chat
- [ ] Verify progress bar still updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)