### PR TITLE
Fix version display in deployed Lambda

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ cp -r ../client/dist .aws-sam/build/PlatoApiFunction/client-dist
 mkdir -p .aws-sam/build/PlatoApiFunction/client-content .aws-sam/build/PlatoStreamFunction/client-content
 cp -r ../client/prompts ../client/data .aws-sam/build/PlatoApiFunction/client-content/
 cp -r ../client/prompts ../client/data .aws-sam/build/PlatoStreamFunction/client-content/
+cp ../version.json .aws-sam/build/PlatoApiFunction/
+cp ../version.json .aws-sam/build/PlatoStreamFunction/
 sam deploy
 ```
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ cp -r ../client/dist .aws-sam/build/PlatoApiFunction/client-dist
 mkdir -p .aws-sam/build/PlatoApiFunction/client-content .aws-sam/build/PlatoStreamFunction/client-content
 cp -r ../client/prompts ../client/data .aws-sam/build/PlatoApiFunction/client-content/
 cp -r ../client/prompts ../client/data .aws-sam/build/PlatoStreamFunction/client-content/
+cp ../version.json .aws-sam/build/PlatoApiFunction/
+cp ../version.json .aws-sam/build/PlatoStreamFunction/
 
 # Deploy
 sam deploy
@@ -280,6 +282,9 @@ jobs:
           mkdir -p server/.aws-sam/build/PlatoApiFunction/client-content server/.aws-sam/build/PlatoStreamFunction/client-content
           cp -r client/prompts client/data server/.aws-sam/build/PlatoApiFunction/client-content/
           cp -r client/prompts client/data server/.aws-sam/build/PlatoStreamFunction/client-content/
+      - run: |
+          cp version.json server/.aws-sam/build/PlatoApiFunction/
+          cp version.json server/.aws-sam/build/PlatoStreamFunction/
       - run: >
           cd server && sam deploy
           --config-env ci

--- a/server/src/routes/content.js
+++ b/server/src/routes/content.js
@@ -18,8 +18,8 @@ content.use('/v1/knowledge-base', authenticate);
 // GET /v1/version — public
 content.get('/v1/version', (c) => {
   const paths = [
-    join(__dirname, '../../../version.json'),       // local dev
-    join(__dirname, '../../version.json'),           // Lambda build
+    join(__dirname, '../../../version.json'),       // local dev (server/src/routes -> repo root)
+    join(__dirname, '../../version.json'),           // Lambda build (src/routes -> function root)
   ];
   for (const p of paths) {
     if (existsSync(p)) {


### PR DESCRIPTION
## Summary
- version.json wasn't being copied into Lambda build artifacts
- Added copy step to deploy docs (CLAUDE.md, README.md) and CI/CD template
- Admin sidebar will now show the version in deployed environments

## Test plan
- [ ] Deploy and verify "plato Beta-RC-X" appears at bottom of admin sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)