### PR TITLE
Minor updates: docs, platform constraints, sticky lesson UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Client hot reload: `cd client && npm run dev` (port 5173, proxies API to :3000)
 cd server && npm test
 ```
 
-98 tests. AI route tests mock `ai-provider.js` (not `bedrock.js`).
+85 tests. AI route tests mock `ai-provider.js` (not `bedrock.js`).
 
 ## Deploy to AWS
 
@@ -68,7 +68,7 @@ cp ../version.json .aws-sam/build/PlatoStreamFunction/
 sam deploy
 ```
 
-The copy steps are required — SAM doesn't build the client. `client-dist` serves the SPA; `client-content` provides prompt/lesson/KB source files for seeding and content change management.
+The copy steps are required — SAM doesn't build the client. `client-dist` serves the SPA; `client-content` provides prompt and lesson source files for seeding.
 
 Deploy config: `server/samconfig.toml` (copy from `samconfig.toml.example`, gitignored). See README.md for full deploy guide including CI/CD setup.
 
@@ -107,7 +107,11 @@ The site is served via CloudFront -> Lambda Function URL. The Origin Request Pol
 - Footer text: "Powered by plato." (with period, with GitHub link)
 - User-created lesson IDs start with `custom-`
 - `loadLessons()` merges system lessons (`/v1/lessons`) with user lessons from sync-data
-- Favicon is generated dynamically via canvas: classroom logo on rounded-rect with primary color background
+- Favicon: defaults to plato's; generated dynamically when admin uploads a logo image (logo on rounded-rect with primary color)
+- Lesson drafts: admins can save lessons as drafts (hidden from learners), preview in sandbox mode, then publish
+- Lesson editing: conversation-based via the Lesson Creator agent (no raw markdown editor)
+- Knowledge base: created/edited by admins via the KB Editor agent in the Customizer (not directly editable)
+- Admin nav order: Home, Lessons, Users, Customizer, Integrations
 
 ## Key files
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Lessons are designed for completion within 11 exchanges, but the system never cu
 
 The admin dashboard tracks an **On-Target Rate** KPI showing what percentage of lessons complete within the 11-exchange target, helping educators tune lesson design.
 
-Admins manage everything from `/plato`: users, lessons, system prompts, a program knowledge base, and visual theming.
+Admins manage everything from `/plato`: lessons, users, a classroom customizer (styles + knowledge base), and integrations.
 
 ## Repository structure
 
@@ -71,7 +71,7 @@ node dev-sqlite.js
 
 Open [http://localhost:3000](http://localhost:3000).
 
-On first visit you'll create an admin account. Prompts, lessons, and the knowledge base are seeded automatically.
+On first visit you'll name your classroom and create an admin account. Prompts and lessons are seeded automatically. The knowledge base is created by admins through the conversational KB Editor in the Customizer.
 
 ### AI provider
 
@@ -138,7 +138,7 @@ Hono framework on AWS Lambda with DynamoDB (or SQLite for local dev). Two Lambda
 
 **DynamoDB tables:** users, invites, refresh-tokens, sync-data, audit-log
 
-All content (system prompts, lessons, knowledge base, theme/branding) is stored in the sync-data table under a `_system` user — no additional tables needed.
+All content (system prompts, lessons, knowledge base, theme/branding, classroom identity) is stored in the sync-data table under a `_system` user — no additional tables needed.
 
 **Auth:** JWT access tokens (15 min) + refresh tokens (30 day, rotated). Invite-based registration. First-time setup creates the initial admin via a UI flow.
 
@@ -148,12 +148,14 @@ All content (system prompts, lessons, knowledge base, theme/branding) is stored 
 |-------|------|
 | **Coach** | Learner's companion in one continuous conversation — coaches, creates activities, evaluates submissions, tracks progress |
 | **Lesson Owner** | Initializes a lesson knowledge base from the lesson prompt + learner profile |
-| **Lesson Creator** | Guides users through designing custom lessons via chat |
+| **Lesson Creator** | Guides admins through designing lessons via conversation |
 | **Lesson Extractor** | Extracts lesson markdown from a creation conversation |
+| **Knowledge Base Editor** | Helps admins create and edit the program knowledge base via conversation |
+| **Knowledge Base Extractor** | Merges existing KB with conversation changes to produce updated markdown |
 | **Learner Profile Owner** | Deep profile update on lesson completion |
 | **Learner Profile Update** | Incremental profile update from feedback/observations |
 
-System prompts are stored in the database and editable by admins at `/plato/prompts`. Changes take effect immediately.
+System prompts are bundled in `client/prompts/` and upserted to the database on every server startup. Admins cannot edit prompts directly — prompt changes are deployed through code updates.
 
 ## Deploying to AWS
 
@@ -201,7 +203,7 @@ cd server && sam build
 cp -r ../client/dist .aws-sam/build/PlatoStreamFunction/client-dist
 cp -r ../client/dist .aws-sam/build/PlatoApiFunction/client-dist
 
-# Bundle content source files (prompts, lessons, KB) for seeding and change management
+# Bundle content source files (prompts, lessons) for seeding
 mkdir -p .aws-sam/build/PlatoApiFunction/client-content .aws-sam/build/PlatoStreamFunction/client-content
 cp -r ../client/prompts ../client/data .aws-sam/build/PlatoApiFunction/client-content/
 cp -r ../client/prompts ../client/data .aws-sam/build/PlatoStreamFunction/client-content/

--- a/client/prompts/coach.md
+++ b/client/prompts/coach.md
@@ -26,6 +26,14 @@ You receive a JSON context as the first message containing:
 
 You also receive the program knowledge base and the conversation history.
 
+## Platform constraints
+
+Learners interact with you entirely through this chat. Their only input methods are:
+- **Text responses** — typed messages
+- **Image uploads** — screenshots, photos (JPEG, PNG, WebP)
+
+Do NOT ask learners to upload videos, audio, PDFs, documents, or other file types. Do NOT ask them to share links you can visit, run code in a terminal, or use external desktop applications. All activities must be completable through text responses or image uploads.
+
 ## Your role
 
 1. **Coach**: Suggest what to work on. Ask probing questions. Point to resources. Guide the learner toward the exemplar one step at a time.

--- a/client/prompts/lesson-creator.md
+++ b/client/prompts/lesson-creator.md
@@ -48,6 +48,24 @@ This means:
 - **Learning objectives** must be demonstrable skills or competencies — things an assessor can evaluate from a text response or uploaded image. They should build coherently toward the exemplar.
 - The exemplar and objectives together must give the Coach enough direction to design meaningful activities and the Assessor enough criteria to evaluate work.
 
+## Platform constraints — what learners can do
+
+Learners interact with the Coach entirely through a chat interface. Their only input methods are:
+
+1. **Text responses** — typed messages in the chat
+2. **Image uploads** — screenshots, photos, or other images (JPEG, PNG, WebP)
+
+That's it. Learners **cannot**:
+- Upload videos, audio, PDFs, documents, spreadsheets, or any other file types
+- Share links that the Coach can visit or scrape
+- Run code in the platform
+- Access external tools, terminals, or desktop applications from within plato
+
+**This directly affects lesson design.** When helping admins design lessons:
+- The exemplar must be something demonstrable via text or image. "Write a reflection" or "create a wireframe and upload a screenshot" work. "Record a video presentation" does not.
+- Objectives must be assessable from text or images. "Can draft a project brief" works. "Can deliver a verbal pitch" does not.
+- If an admin proposes an exemplar or activity requiring unsupported input, push back immediately: "plato only supports text and image uploads. The Coach won't be able to assess [video/audio/etc]. Can we reframe this as something the learner writes or screenshots?"
+
 ## Your conversation flow
 
 ### Phase 1: Explore (readiness 1-3)
@@ -108,6 +126,7 @@ In EVERY response, weave in a natural sense of where things stand. Don't just as
 - When the user seems to want to rush: "A well-designed lesson produces better activities and assessments. Let's make sure the foundation is solid."
 - If the user proposes more than 4 objectives, push back: "For a 20-minute lesson, you need 2-4 focused objectives. Which ones are essential to the exemplar? Let's cut the rest or combine them."
 - Always end with a specific, actionable question or statement that moves the conversation forward.
+- If the admin describes activities involving video uploads, audio recording, file attachments, link sharing, code execution, or any input besides text and images — stop and redirect: "plato only supports text and image uploads right now. Let's design this so learners can demonstrate it through writing or screenshots."
 
 ## Readiness signal
 

--- a/client/src/components/chat/ChatArea.jsx
+++ b/client/src/components/chat/ChatArea.jsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, forwardRef } from 'react';
 
-const NEAR_BOTTOM_PX = 80;
+const NEAR_BOTTOM_PX = 150; // accounts for fixed compose bar + spacer
 
 const ChatArea = forwardRef(function ChatArea({ children, lessonName }, ref) {
   const localRef = useRef(null);
@@ -12,13 +12,22 @@ const ChatArea = forwardRef(function ChatArea({ children, lessonName }, ref) {
     const el = typeof scrollRef === 'function' ? null : scrollRef.current;
     if (!el) return;
 
+    // Find the nearest scrolling ancestor for auto-scroll behavior
+    let sc = el.parentElement;
+    while (sc && sc !== document.documentElement) {
+      const { overflowY } = getComputedStyle(sc);
+      if (overflowY === 'auto' || overflowY === 'scroll') break;
+      sc = sc.parentElement;
+    }
+    const scrollContainer = sc || document.documentElement;
+
     function isNearBottom() {
-      return el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_PX;
+      return scrollContainer.scrollHeight - scrollContainer.scrollTop - scrollContainer.clientHeight < NEAR_BOTTOM_PX;
     }
 
     function scrollToBottom() {
       programmaticScroll.current = true;
-      el.scrollTop = el.scrollHeight;
+      scrollContainer.scrollTop = scrollContainer.scrollHeight;
     }
 
     function handleScroll() {
@@ -34,17 +43,17 @@ const ChatArea = forwardRef(function ChatArea({ children, lessonName }, ref) {
     });
 
     observer.observe(el, { childList: true, subtree: true, characterData: true });
-    el.addEventListener('scroll', handleScroll);
+    scrollContainer.addEventListener('scroll', handleScroll);
 
     return () => {
       observer.disconnect();
-      el.removeEventListener('scroll', handleScroll);
+      scrollContainer.removeEventListener('scroll', handleScroll);
     };
   }, [scrollRef]);
 
   return (
     <div
-      className="flex-1 overflow-y-auto p-4 text-base"
+      className="p-4 text-base"
       role="log"
       aria-live="polite"
       aria-label={lessonName ? `${lessonName} conversation` : 'Lesson conversation'}

--- a/client/src/components/chat/ComposeBar.jsx
+++ b/client/src/components/chat/ComposeBar.jsx
@@ -7,6 +7,7 @@ export default function ComposeBar({
   onSend,
   disabled = false,
   allowImages = false,
+  elevated = false,
 }) {
   const [text, setText] = useState('');
   const [image, setImage] = useState(null);
@@ -38,7 +39,7 @@ export default function ComposeBar({
 
   return (
     <div className="px-4 pb-4 pt-2">
-      <div className="mx-auto max-w-3xl rounded-lg border border-input bg-background">
+      <div className={`mx-auto max-w-3xl rounded-lg border border-input bg-background ${elevated ? 'shadow-lg' : ''}`}>
         {image && (
           <div className="relative m-2 inline-block">
             <img src={image.dataUrl} alt={image.name} className="h-20 rounded-md object-cover" />

--- a/client/src/pages/LessonChat.jsx
+++ b/client/src/pages/LessonChat.jsx
@@ -19,6 +19,10 @@ import ProgressBar from '../components/chat/ProgressBar.jsx';
 import ComposeBar from '../components/chat/ComposeBar.jsx';
 import ConfirmModal from '../components/modals/ConfirmModal.jsx';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle,
+  DialogDescription, DialogFooter,
+} from '@/components/ui/dialog';
 
 export default function LessonChat() {
   const { lessonGroupId } = useParams();
@@ -39,6 +43,33 @@ export default function LessonChat() {
 
   // Confirm modal state
   const [confirmModal, setConfirmModal] = useState(null);
+  const [showObjectives, setShowObjectives] = useState(false);
+  const [headerPinned, setHeaderPinned] = useState(false);
+  const headerRef = useRef(null);
+  const [composePinned, setComposePinned] = useState(true);
+  const composeAnchorRef = useRef(null);
+
+  // Pin header when its top edge reaches the viewport top
+  useEffect(() => {
+    const el = headerRef.current;
+    if (!el) return;
+    const check = () => {
+      const rect = el.getBoundingClientRect();
+      setHeaderPinned(rect.top < 0);
+    };
+    const checkCompose = () => {
+      const anchor = composeAnchorRef.current;
+      if (anchor) {
+        const rect = anchor.getBoundingClientRect();
+        // Unpin only when the bottom of the inline compose is fully visible
+        setComposePinned(rect.bottom > window.innerHeight);
+      }
+    };
+    const checkAll = () => { check(); checkCompose(); };
+    window.addEventListener('scroll', checkAll, true);
+    checkAll();
+    return () => window.removeEventListener('scroll', checkAll, true);
+  }, []);
 
   useEffect(() => {
     if (displayText === null && pendingAfterStreamRef.current) {
@@ -81,7 +112,7 @@ export default function LessonChat() {
     })();
 
     return () => { cancelled = true; };
-  }, [lessonGroupId]);
+  }, [lessonGroupId, lesson]);
 
   const handleSend = useCallback(async ({ text, imageDataUrl }) => {
     if (!text && !imageDataUrl) return;
@@ -152,6 +183,7 @@ export default function LessonChat() {
     });
   };
 
+  if (!state.loaded) return <div className="flex items-center justify-center py-12 text-muted-foreground" role="status" aria-live="polite">Loading...</div>;
   if (!lesson) return <p className="p-4 text-muted-foreground">Lesson not found.</p>;
   const busy = !!loading;
 
@@ -178,32 +210,80 @@ export default function LessonChat() {
   };
 
   return (
-    <div className="flex flex-col h-full">
-      <div className="border-b border-border bg-background px-4 py-2">
-      <div className="mx-auto max-w-5xl flex items-center gap-2">
-        <Button variant="ghost" size="icon-sm" aria-label="Back to lessons" onClick={() => navigate('/lessons')}>
-          &larr;
-        </Button>
-        <div className="flex-1 min-w-0">
-          <h2 className="text-sm font-semibold truncate">{lesson.name}</h2>
-          <ProgressBar lessonKB={lessonKB} />
+    <div>
+      {/* Fixed header clone — appears when inline header scrolls out of view */}
+      {headerPinned && (
+        <div id="lesson-header-pinned" aria-hidden="true" className="fixed top-0 left-0 right-0 z-50 border-b border-border bg-background px-4 py-2 shadow-md">
+          <div className="mx-auto max-w-5xl flex items-center gap-2">
+            <Button variant="ghost" size="icon-sm" aria-label="Back to lessons" onClick={() => navigate('/lessons')}>
+              &larr;
+            </Button>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center justify-between gap-2">
+                <h2 className="text-sm font-semibold truncate">{lesson.name}</h2>
+                <button
+                  className="text-xs text-primary hover:underline shrink-0"
+                  onClick={() => setShowObjectives(true)}
+                >
+                  Overview ({lesson.learningObjectives.length} Objectives)
+                </button>
+              </div>
+              <ProgressBar lessonKB={lessonKB} />
+            </div>
+            {isCustomLesson && (
+              <Button variant="ghost" size="icon-sm" onClick={handleExport} title="Export lesson markdown">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+              </Button>
+            )}
+            {phase && (
+              <Button variant="ghost" size="icon-sm" onClick={handleReset} title="Reset lesson">
+                &#8635;
+              </Button>
+            )}
+            {isCustomLesson && (
+              <Button variant="ghost" size="icon-sm" onClick={handleDelete} title="Delete lesson">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+              </Button>
+            )}
+          </div>
         </div>
-        {isCustomLesson && (
-          <Button variant="ghost" size="icon-sm" onClick={handleExport} aria-label="Export lesson" title="Export lesson markdown">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+      )}
+
+      {/* Inline header — observed for scroll position */}
+      <div ref={headerRef} id="lesson-header" className="border-b border-border bg-background px-4 py-2">
+        <div className="mx-auto max-w-5xl flex items-center gap-2">
+          <Button variant="ghost" size="icon-sm" aria-label="Back to lessons" onClick={() => navigate('/lessons')}>
+            &larr;
           </Button>
-        )}
-        {phase && (
-          <Button variant="ghost" size="icon-sm" onClick={handleReset} aria-label="Reset lesson" title="Reset lesson">
-            &#8635;
-          </Button>
-        )}
-        {isCustomLesson && (
-          <Button variant="ghost" size="icon-sm" onClick={handleDelete} aria-label="Delete lesson" title="Delete lesson">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
-          </Button>
-        )}
-      </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center justify-between gap-2">
+              <h2 className="text-sm font-semibold truncate">{lesson.name}</h2>
+              <button
+                className="text-xs text-primary hover:underline shrink-0"
+                onClick={() => setShowObjectives(true)}
+                aria-label={`View ${lesson.learningObjectives.length} objectives`}
+              >
+                Overview ({lesson.learningObjectives.length} Objectives)
+              </button>
+            </div>
+            <ProgressBar lessonKB={lessonKB} />
+          </div>
+          {isCustomLesson && (
+            <Button variant="ghost" size="icon-sm" onClick={handleExport} aria-label="Export lesson" title="Export lesson markdown">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+            </Button>
+          )}
+          {phase && (
+            <Button variant="ghost" size="icon-sm" onClick={handleReset} aria-label="Reset lesson" title="Reset lesson">
+              &#8635;
+            </Button>
+          )}
+          {isCustomLesson && (
+            <Button variant="ghost" size="icon-sm" onClick={handleDelete} aria-label="Delete lesson" title="Delete lesson">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+            </Button>
+          )}
+        </div>
       </div>
 
       <ChatArea lessonName={lesson?.name}>
@@ -216,14 +296,55 @@ export default function LessonChat() {
         {error && <div className="px-3 py-2 text-sm text-destructive" role="alert">{error}</div>}
       </ChatArea>
 
+      {/* Inline compose — always in document flow for layout; invisible when pinned */}
       {phase && (
-        <ComposeBar
-          placeholder={phase === LESSON_PHASES.COMPLETED ? "Continue chatting..." : "Chat with your coach..."}
-          onSend={handleSend}
-          disabled={busy}
-          allowImages
-        />
+        <div ref={composeAnchorRef} aria-hidden={composePinned || undefined} className={composePinned ? 'invisible' : ''}>
+          <ComposeBar
+            placeholder={phase === LESSON_PHASES.COMPLETED ? "Continue chatting..." : "Chat with your coach..."}
+            onSend={handleSend}
+            disabled={busy}
+            allowImages
+          />
+        </div>
       )}
+
+      {/* Fixed compose overlay — interactive when pinned */}
+      {phase && composePinned && (
+        <div className="fixed bottom-0 left-0 right-0 z-50">
+          <ComposeBar
+            placeholder={phase === LESSON_PHASES.COMPLETED ? "Continue chatting..." : "Chat with your coach..."}
+            onSend={handleSend}
+            disabled={busy}
+            allowImages
+            elevated
+          />
+        </div>
+      )}
+
+      {/* Objectives dialog */}
+      <Dialog open={showObjectives} onOpenChange={setShowObjectives}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{lesson.name}</DialogTitle>
+            {lesson.description && <DialogDescription>{lesson.description}</DialogDescription>}
+          </DialogHeader>
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium">Exemplar</h3>
+            <p className="text-sm text-muted-foreground leading-relaxed">{lesson.exemplar}</p>
+          </div>
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium">Learning Objectives</h3>
+            <ul className="list-disc pl-5 text-sm text-muted-foreground leading-relaxed space-y-1">
+              {lesson.learningObjectives.map((obj, i) => (
+                <li key={i}>{obj}</li>
+              ))}
+            </ul>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowObjectives(false)}>Close</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {confirmModal && (
         <ConfirmModal

--- a/client/src/pages/LessonsList.jsx
+++ b/client/src/pages/LessonsList.jsx
@@ -83,10 +83,13 @@ export default function LessonsList() {
               <div className="flex items-center gap-2 flex-wrap">
                 {c.lessonId.startsWith('custom-') && <Badge variant="outline" className="text-xs">My Lesson</Badge>}
                 {progressLabel(c) && <Badge variant="secondary" className="text-xs">{progressLabel(c)}</Badge>}
-                <button className="text-xs text-primary hover:underline"
-                  onClick={(e) => { e.stopPropagation(); setDetailLesson(c); }}>
+                <span className="text-xs text-primary hover:underline cursor-pointer"
+                  role="button" tabIndex={0}
+                  onClick={(e) => { e.stopPropagation(); setDetailLesson(c); }}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.stopPropagation(); e.preventDefault(); setDetailLesson(c); } }}
+                  aria-label={`View ${c.learningObjectives.length} objectives for ${c.name}`}>
                   {c.learningObjectives.length} objectives
-                </button>
+                </span>
               </div>
             </div>
           </LessonItem>


### PR DESCRIPTION
## Summary

- **Docs**: CLAUDE.md, README.md, CONTRIBUTING.md updated with current feature set (85 tests, 8 agents, classroom customizer)
- **Platform constraints**: lesson-creator and coach agents now know plato only supports text + image uploads — reject video/audio/PDF activities
- **Sticky lesson header**: pinned clone with shadow when scrolled past, includes all action buttons
- **Sticky compose bar**: fixed at viewport bottom, unpins at page end, shadow only when pinned
- **Objectives dialog**: "Overview (N Objectives)" link in lesson header
- **Classroom identity**: name field on Setup page, text logo when no image, favicon defaults to plato's
- **Hard refresh fix**: lesson chat no longer goes blank on shift+refresh

## Test plan

- [ ] `cd server && npm test` — 85 tests pass
- [ ] Lesson chat: header pins on scroll with shadow, unpins when scrolled back
- [ ] Lesson chat: compose bar pins at bottom, unpins at page end
- [ ] Lesson chat: shift+refresh loads correctly
- [ ] Setup page: classroom name field present
- [ ] Customizer > Styles: classroom identity section with name + optional logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)