### PR TITLE
Lesson UI polish, agent catalog awareness, admin confirmations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ plato is an open-source, AI-powered [microlearning](https://philosophers.group/p
   - **learner-profile-owner** — Reads: learner profile, lesson KB. Full profile update on lesson completion.
   - **learner-profile-update** — Reads: learner profile, activity context. Incremental profile updates during lessons.
 - Program Knowledge Base is appended to agent system prompts at runtime for agents in `KB_AGENTS` (`client/js/orchestrator.js`)
+- Lesson Catalog appended at runtime: published-only for `PUBLISHED_CATALOG_AGENTS` (coach), full list with draft status for `ADMIN_CATALOG_AGENTS` (lesson-creator, knowledge-base-editor)
 - Microlearning constraints defined in `client/src/lib/constants.js`: MAX_EXCHANGES=11, MIN_OBJECTIVES=2, MAX_OBJECTIVES=4. Server mirrors in `server/src/lib/lesson-limits.js`. Prompts reference these as literal numbers (update both if changed).
 - Pacing: lessons target 11 exchanges (~20 min). No hard cutoff — coach gets escalating `pacingDirective` in context JSON at 11+, 15+, 20+ exchanges. Hard limit at 2x target (22) as safety net.
 - Classroom branding (colors, logo, name) stored in `_system` settings, fetched via `/v1/branding` (public, no auth)

--- a/client/js/orchestrator.js
+++ b/client/js/orchestrator.js
@@ -33,6 +33,38 @@ async function loadKnowledgeBase() {
 }
 
 const KB_AGENTS = ['coach', 'lesson-creator', 'knowledge-base-editor'];
+// Agents that see published lessons only (learner-facing)
+const PUBLISHED_CATALOG_AGENTS = ['coach'];
+// Agents that see all lessons including drafts (admin-only)
+const ADMIN_CATALOG_AGENTS = ['lesson-creator', 'knowledge-base-editor'];
+
+let publishedCatalog = null;
+let adminCatalog = null;
+
+async function loadPublishedCatalog() {
+  if (publishedCatalog) return publishedCatalog;
+  try {
+    const resp = await authenticatedFetch('/v1/lessons');
+    const lessons = resp.ok ? await resp.json() : [];
+    if (!lessons.length) { publishedCatalog = ''; return ''; }
+    publishedCatalog = lessons.map(l => `- ${l.name || l.lessonId}`).join('\n');
+  } catch { publishedCatalog = ''; }
+  return publishedCatalog;
+}
+
+async function loadAdminCatalog() {
+  if (adminCatalog) return adminCatalog;
+  try {
+    const resp = await authenticatedFetch('/v1/admin/lessons');
+    const lessons = resp.ok ? await resp.json() : [];
+    if (!lessons.length) { adminCatalog = ''; return ''; }
+    adminCatalog = lessons.map(l => {
+      const status = l.status === 'draft' ? ' [DRAFT]' : '';
+      return `- ${l.name || l.lessonId}${status}`;
+    }).join('\n');
+  } catch { adminCatalog = ''; }
+  return adminCatalog;
+}
 
 function parseJSON(text) {
   const trimmed = text.trim();
@@ -82,6 +114,8 @@ async function callApi({ model, systemPrompt, messages, maxTokens = 1024 }) {
   throw lastError;
 }
 
+export function invalidateLessonCatalog() { publishedCatalog = null; adminCatalog = null; }
+
 export async function isReady() {
   return true;
 }
@@ -93,6 +127,13 @@ export async function converseStream(promptName, messages, onChunk, maxTokens = 
   if (KB_AGENTS.includes(promptName)) {
     const kb = await loadKnowledgeBase();
     if (kb) systemPrompt = `${systemPrompt}\n\n---\n\n## Program Knowledge Base\n\n${kb}`;
+  }
+  if (ADMIN_CATALOG_AGENTS.includes(promptName)) {
+    const catalog = await loadAdminCatalog();
+    if (catalog) systemPrompt = `${systemPrompt}\n\n---\n\n## Current Lessons in This Classroom\n\n${catalog}`;
+  } else if (PUBLISHED_CATALOG_AGENTS.includes(promptName)) {
+    const catalog = await loadPublishedCatalog();
+    if (catalog) systemPrompt = `${systemPrompt}\n\n---\n\n## Lessons in This Classroom\n\n${catalog}`;
   }
 
   const resp = await authenticatedFetch('/v1/ai/messages', {

--- a/client/prompts/coach.md
+++ b/client/prompts/coach.md
@@ -1,6 +1,6 @@
 <!--
   AGENT: Coach
-  READS: Lesson prompt, Lesson KB, Learner profile, Program Knowledge Base (appended at runtime)
+  READS: Lesson prompt, Lesson KB, Learner profile, Program Knowledge Base + Lesson Catalog (appended at runtime)
   CALLED BY: lessonEngine.js (startLesson, sendMessage)
   PURPOSE: Learner's companion, teacher, and assessor — coaches toward the lesson exemplar
   LIMITS: ~11 exchanges (~20 min) — defined in client/src/lib/constants.js
@@ -33,6 +33,13 @@ Learners interact with you entirely through this chat. Their only input methods 
 - **Image uploads** — screenshots, photos (JPEG, PNG, WebP)
 
 Do NOT ask learners to upload videos, audio, PDFs, documents, or other file types. Do NOT ask them to share links you can visit, run code in a terminal, or use external desktop applications. All activities must be completable through text responses or image uploads.
+
+## Lesson catalog awareness
+
+You receive a list of all lessons in this classroom (appended at the end of this prompt). Use it to:
+- **Connect lessons** — if a learner mentions something covered in another lesson, you can reference it ("that's explored in depth in [lesson name]")
+- **Suggest next steps** — after completion, you can suggest related lessons from the catalog
+- Do NOT pressure learners to take other lessons — only mention them when naturally relevant
 
 ## Your role
 

--- a/client/prompts/knowledge-base-editor.md
+++ b/client/prompts/knowledge-base-editor.md
@@ -1,6 +1,6 @@
 <!--
   AGENT: Knowledge Base Editor
-  READS: Program Knowledge Base (appended to this prompt at runtime)
+  READS: Program Knowledge Base + Lesson Catalog (both appended to this prompt at runtime)
   CALLED BY: AdminCustomizer (Knowledge tab), AdminKBSetup (post-login setup)
   PURPOSE: Help admins create and maintain the program knowledge base through conversation
   

--- a/client/prompts/lesson-creator.md
+++ b/client/prompts/lesson-creator.md
@@ -1,6 +1,6 @@
 <!--
   AGENT: Lesson Creator
-  READS: Program Knowledge Base (appended to this prompt at runtime)
+  READS: Program Knowledge Base + Lesson Catalog (both appended to this prompt at runtime)
   CALLED BY: AdminLessons (NewLessonView — create and edit lessons)
   PURPOSE: Help admins design well-structured microlearning lessons through conversation
   LIMITS: 2-4 objectives, ~11 exchanges — defined in client/src/lib/constants.js
@@ -65,6 +65,14 @@ That's it. Learners **cannot**:
 - The exemplar must be something demonstrable via text or image. "Write a reflection" or "create a wireframe and upload a screenshot" work. "Record a video presentation" does not.
 - Objectives must be assessable from text or images. "Can draft a project brief" works. "Can deliver a verbal pitch" does not.
 - If an admin proposes an exemplar or activity requiring unsupported input, push back immediately: "plato only supports text and image uploads. The Coach won't be able to assess [video/audio/etc]. Can we reframe this as something the learner writes or screenshots?"
+
+## Lesson catalog awareness
+
+You receive a list of all current lessons in this classroom (appended at the end of this prompt). Use it to:
+- **Avoid duplication** — if the admin is creating a lesson that overlaps with an existing one, point it out and suggest differentiation
+- **Build coherence** — help the admin design lessons that complement the existing catalog, not repeat it
+- **Reference context** — if the admin mentions "the first lesson" or "the intro lesson", you can identify which one they mean
+- Lessons marked [DRAFT] are not yet visible to learners
 
 ## Your conversation flow
 

--- a/client/src/components/chat/ChatArea.jsx
+++ b/client/src/components/chat/ChatArea.jsx
@@ -12,14 +12,17 @@ const ChatArea = forwardRef(function ChatArea({ children, lessonName }, ref) {
     const el = typeof scrollRef === 'function' ? null : scrollRef.current;
     if (!el) return;
 
-    // Find the nearest scrolling ancestor for auto-scroll behavior
-    let sc = el.parentElement;
+    // Find the scroll container — could be the element itself or a parent
+    let scrollContainer = document.documentElement;
+    let sc = el;
     while (sc && sc !== document.documentElement) {
       const { overflowY } = getComputedStyle(sc);
-      if (overflowY === 'auto' || overflowY === 'scroll') break;
+      if (overflowY === 'auto' || overflowY === 'scroll') {
+        scrollContainer = sc;
+        break;
+      }
       sc = sc.parentElement;
     }
-    const scrollContainer = sc || document.documentElement;
 
     function isNearBottom() {
       return scrollContainer.scrollHeight - scrollContainer.scrollTop - scrollContainer.clientHeight < NEAR_BOTTOM_PX;

--- a/client/src/components/chat/UserMessage.jsx
+++ b/client/src/components/chat/UserMessage.jsx
@@ -1,7 +1,7 @@
 export default function UserMessage({ content, label }) {
   return (
     <div className="flex justify-end" role="article" aria-label="Your message">
-      <div className="max-w-[85%] rounded-2xl rounded-br-sm bg-primary px-4 py-3 text-base text-primary-foreground font-sans">
+      <div className="max-w-[85%] rounded-2xl rounded-br-sm bg-primary px-4 py-3 text-base text-primary-foreground font-sans break-words overflow-hidden">
         <p>{label && <strong>{label}: </strong>}{content}</p>
       </div>
     </div>

--- a/client/src/components/modals/ConfirmModal.jsx
+++ b/client/src/components/modals/ConfirmModal.jsx
@@ -24,7 +24,11 @@ export default function ConfirmModal({
         <AlertDialogFooter>
           <AlertDialogCancel>{cancelLabel}</AlertDialogCancel>
           <AlertDialogAction
-            className={variant === 'destructive' ? 'bg-destructive/10 text-destructive hover:bg-destructive/20' : undefined}
+            className={
+              variant === 'destructive' ? 'bg-destructive/10 text-destructive hover:bg-destructive/20'
+              : variant === 'success' ? 'bg-green-600 text-white hover:bg-green-700'
+              : undefined
+            }
             onClick={() => { onConfirm(); }}
           >
             {confirmLabel}

--- a/client/src/pages/LessonChat.jsx
+++ b/client/src/pages/LessonChat.jsx
@@ -222,7 +222,7 @@ export default function LessonChat() {
               <div className="flex items-center justify-between gap-2">
                 <h2 className="text-sm font-semibold truncate">{lesson.name}</h2>
                 <button
-                  className="text-xs text-primary hover:underline shrink-0"
+                  className="text-xs text-primary hover:underline shrink-0 cursor-pointer"
                   onClick={() => setShowObjectives(true)}
                 >
                   Lesson Overview ({lesson.learningObjectives.length} Objectives)
@@ -259,7 +259,7 @@ export default function LessonChat() {
             <div className="flex items-center justify-between gap-2">
               <h2 className="text-sm font-semibold truncate">{lesson.name}</h2>
               <button
-                className="text-xs text-primary hover:underline shrink-0"
+                className="text-xs text-primary hover:underline shrink-0 cursor-pointer"
                 onClick={() => setShowObjectives(true)}
                 aria-label={`View ${lesson.learningObjectives.length} objectives`}
               >

--- a/client/src/pages/admin/AdminCustomizer.jsx
+++ b/client/src/pages/admin/AdminCustomizer.jsx
@@ -435,7 +435,7 @@ function KBEditor({ initialContent, onSave, onCancel }) {
       )}
 
       <div className="rounded-2xl bg-muted/40 border border-border p-4">
-        <div className="mb-3 [&>div]:max-h-[500px]">
+        <div className="mb-3">
           <ChatArea lessonName="Knowledge Base Editor">
             {chatMessages.map(renderMessage)}
             {displayText != null && displayText.length > 0 && (

--- a/client/src/pages/admin/AdminKBSetup.jsx
+++ b/client/src/pages/admin/AdminKBSetup.jsx
@@ -174,7 +174,7 @@ export default function AdminKBSetup() {
       )}
 
       <div className="rounded-2xl bg-muted/40 border border-border p-4">
-        <div className="mb-3 [&>div]:max-h-[500px]">
+        <div className="mb-3">
           <ChatArea lessonName="Knowledge Base Editor">
             {chatMessages.map(renderMessage)}
             {displayText != null && displayText.length > 0 && (

--- a/client/src/pages/admin/AdminLessonPreview.jsx
+++ b/client/src/pages/admin/AdminLessonPreview.jsx
@@ -15,6 +15,10 @@ import ThinkingSpinner from '../../components/chat/ThinkingSpinner.jsx';
 import ProgressBar from '../../components/chat/ProgressBar.jsx';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle,
+  DialogDescription, DialogFooter,
+} from '@/components/ui/dialog';
 
 export default function AdminLessonPreview() {
   const { lessonId } = useParams();
@@ -24,6 +28,7 @@ export default function AdminLessonPreview() {
   const [lessonKB, setLessonKB] = useState(null);
   const [messages, setMessages] = useState([]);
   const [loading, setLoading] = useState('');
+  const [showObjectives, setShowObjectives] = useState(false);
   const [error, setError] = useState('');
   const [isDraft, setIsDraft] = useState(false);
 
@@ -159,8 +164,10 @@ export default function AdminLessonPreview() {
   return (
     <main className="flex flex-col h-full" aria-label="Lesson preview">
       {/* Preview banner */}
-      <div className="bg-amber-50 border-b border-amber-200 px-4 py-2 text-center text-sm text-amber-800" role="status" aria-live="polite">
-        Preview Mode — this conversation is not saved
+      <div className="px-4 pt-4 mb-4">
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800" role="status" aria-live="polite">
+          <strong>Preview Mode</strong> — this conversation is not saved
+        </div>
       </div>
 
       {/* Header */}
@@ -170,9 +177,20 @@ export default function AdminLessonPreview() {
             &larr;
           </Button>
           <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2">
-              <h1 className="text-sm font-semibold truncate">{lesson?.name || 'Loading...'}</h1>
-              {isDraft && <Badge variant="outline" className="text-xs">Draft</Badge>}
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2 min-w-0">
+                <h1 className="text-sm font-semibold truncate">{lesson?.name || 'Loading...'}</h1>
+                {isDraft && <Badge variant="outline" className="text-xs">Draft</Badge>}
+              </div>
+              {lesson && (
+                <button
+                  className="text-xs text-primary hover:underline shrink-0 cursor-pointer"
+                  onClick={() => setShowObjectives(true)}
+                  aria-label={`View ${lesson.learningObjectives.length} objectives`}
+                >
+                  Lesson Overview ({lesson.learningObjectives.length} Objectives)
+                </button>
+              )}
             </div>
             <ProgressBar lessonKB={lessonKB} />
           </div>
@@ -200,6 +218,33 @@ export default function AdminLessonPreview() {
           onSend={handleSend}
           disabled={busy}
         />
+      )}
+
+      {/* Objectives dialog */}
+      {lesson && (
+        <Dialog open={showObjectives} onOpenChange={setShowObjectives}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{lesson.name}</DialogTitle>
+              {lesson.description && <DialogDescription>{lesson.description}</DialogDescription>}
+            </DialogHeader>
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium">Exemplar</h3>
+              <p className="text-sm text-muted-foreground leading-relaxed">{lesson.exemplar}</p>
+            </div>
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium">Learning Objectives</h3>
+              <ul className="list-disc pl-5 text-sm text-muted-foreground leading-relaxed space-y-1">
+                {lesson.learningObjectives.map((obj, i) => (
+                  <li key={i}>{obj}</li>
+                ))}
+              </ul>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setShowObjectives(false)}>Close</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       )}
     </main>
   );

--- a/client/src/pages/admin/AdminLessons.jsx
+++ b/client/src/pages/admin/AdminLessons.jsx
@@ -8,6 +8,7 @@ import {
   Table, TableHeader, TableBody, TableRow, TableHead, TableCell,
 } from '@/components/ui/table';
 
+import ConfirmModal from '../../components/modals/ConfirmModal.jsx';
 import { converseStream, extractLessonMarkdown } from '../../../js/orchestrator.js';
 import { parseLessonPrompt } from '../../../js/lessonOwner.js';
 import { parseResponse, cleanStream } from '../../lib/lessonCreationEngine.js';
@@ -29,6 +30,7 @@ export default function AdminLessons() {
   const [editing, setEditing] = useState(null); // { lessonId, conversation, readiness, needsAgentReply }
   const [message, setMessage] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [confirmModal, setConfirmModal] = useState(null);
 
   useEffect(() => {
     document.title = 'Lessons — Admin';
@@ -60,21 +62,38 @@ export default function AdminLessons() {
     } catch (e) { setMessage({ text: e.message, type: 'error' }); }
   }
 
-  async function toggleLessonStatus(lessonId, newStatus) {
-    try {
-      await adminApi('PUT', `/v1/admin/lessons/${encodeURIComponent(lessonId)}`, { status: newStatus });
-      setMessage({ text: newStatus === 'published' ? 'Lesson published.' : 'Lesson unpublished.', type: 'success' });
-      loadLessons();
-    } catch (e) { setMessage({ text: e.message, type: 'error' }); }
+  function toggleLessonStatus(lessonId, newStatus) {
+    const action = newStatus === 'published' ? 'Publish' : 'Unpublish';
+    setConfirmModal({
+      title: `${action} Lesson?`,
+      message: newStatus === 'published'
+        ? 'This lesson will become visible to all learners.'
+        : 'This lesson will be hidden from learners.',
+      confirmLabel: action,
+      variant: newStatus === 'published' ? 'success' : 'destructive',
+      onConfirm: async () => {
+        try {
+          await adminApi('PUT', `/v1/admin/lessons/${encodeURIComponent(lessonId)}`, { status: newStatus });
+          setMessage({ text: `Lesson ${newStatus === 'published' ? 'published' : 'unpublished'}.`, type: 'success' });
+          loadLessons();
+        } catch (e) { setMessage({ text: e.message, type: 'error' }); }
+      },
+    });
   }
 
-  async function deleteLesson(lessonId) {
-    if (!confirm(`Delete lesson "${lessonId}"?`)) return;
-    try {
-      await adminApi('DELETE', `/v1/admin/lessons/${encodeURIComponent(lessonId)}`);
-      setMessage({ text: 'Lesson deleted.', type: 'success' });
-      loadLessons();
-    } catch (e) { setMessage({ text: e.message, type: 'error' }); }
+  function deleteLesson(lessonId) {
+    setConfirmModal({
+      title: 'Delete Lesson?',
+      message: 'This will permanently delete this lesson. This cannot be undone.',
+      confirmLabel: 'Delete Lesson',
+      onConfirm: async () => {
+        try {
+          await adminApi('DELETE', `/v1/admin/lessons/${encodeURIComponent(lessonId)}`);
+          setMessage({ text: 'Lesson deleted.', type: 'success' });
+          loadLessons();
+        } catch (e) { setMessage({ text: e.message, type: 'error' }); }
+      },
+    });
   }
 
   if (loading) return <div className="flex items-center justify-center py-12 text-muted-foreground" role="status" aria-live="polite">Loading...</div>;
@@ -158,7 +177,7 @@ export default function AdminLessons() {
                   <TableCell>
                     <span className="flex items-center gap-2">
                       {c.name || c.lessonId}
-                      {isDraft && <Badge variant="outline" className="text-xs">Draft</Badge>}
+                      <Badge variant="outline" className={`text-xs ${isDraft ? 'border-amber-300 bg-amber-50 text-amber-800' : ''}`}>{isDraft ? 'Draft' : 'Published'}</Badge>
                     </span>
                   </TableCell>
                   <TableCell className="text-muted-foreground">{c.createdByName || '\u2014'}</TableCell>
@@ -176,7 +195,9 @@ export default function AdminLessons() {
                         </Button>
                       )}
                       <Button variant="ghost" size="icon-xs" title="Edit" onClick={() => editLesson(c.lessonId)} aria-label={`Edit ${c.name}`}>&#9998;</Button>
-                      <Button variant="ghost" size="icon-xs" title="Delete" onClick={() => deleteLesson(c.lessonId)} aria-label={`Delete ${c.name}`}>&#10005;</Button>
+                      <Button variant="ghost" size="icon-xs" title="Delete" onClick={() => deleteLesson(c.lessonId)} aria-label={`Delete ${c.name}`}>
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+                      </Button>
                     </div>
                   </TableCell>
                 </TableRow>
@@ -190,6 +211,18 @@ export default function AdminLessons() {
           </TableBody>
         </Table>
       </Card>
+
+      {confirmModal && (
+        <ConfirmModal
+          open={!!confirmModal}
+          onOpenChange={(open) => { if (!open) setConfirmModal(null); }}
+          title={confirmModal.title}
+          message={confirmModal.message}
+          confirmLabel={confirmModal.confirmLabel}
+          variant={confirmModal.variant}
+          onConfirm={() => { setConfirmModal(null); confirmModal.onConfirm(); }}
+        />
+      )}
     </div>
   );
 }
@@ -394,7 +427,7 @@ function NewLessonView({ onSave, onCancel, onError, editingLessonId, initialMess
 
       {/* Chat + compose in a single container */}
       <div className="rounded-2xl bg-muted/40 border border-border p-4">
-        <div className="mb-3 [&>div]:max-h-[500px]">
+        <div className="mb-3">
           <ChatArea lessonName="Lesson Creator">
             {chatMessages.map(renderMessage)}
             {displayText != null && displayText.length > 0 && (


### PR DESCRIPTION
## Summary

- **Agent lesson catalog**: Coach sees published lessons only; Lesson Creator and KB Editor see all including drafts
- **Admin confirmations**: publish (green), unpublish (red), delete (red) with ConfirmModal
- **Draft badge yellow**, Published badge shown for all lessons, trash can icon for delete
- **Lesson preview**: overview link + objectives dialog, banner matches dashboard alert style
- **Chat fixes**: long message overflow, admin chat areas flow with page (no nested scroll)
- **Hard refresh fix**: lesson chat waits for data load before rendering

## Test plan

- [ ] 85 server tests pass
- [ ] Admin lessons: publish shows green confirm, delete shows red confirm
- [ ] Draft badge is yellow, Published badge is default
- [ ] Lesson preview: "Lesson Overview (N Objectives)" link opens dialog
- [ ] Coach doesn't see draft lessons in conversation context
- [ ] Hard refresh on lesson page loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)