### PR TITLE
Hotfix: restore migration + legacy key fallbacks

### DIFF
--- a/client/js/storage.js
+++ b/client/js/storage.js
@@ -112,7 +112,10 @@ export async function saveLearnerProfileSummary(summary) {
 // -- Lesson KB ----------------------------------------------------------------
 
 export async function getLessonKB(lessonId) {
-  return fetchSyncData(`lessonKB:${lessonId}`);
+  // Try new key first, fall back to legacy courseKB: key for unmigrated data
+  const data = await fetchSyncData(`lessonKB:${lessonId}`);
+  if (data) return data;
+  return fetchSyncData(`courseKB:${lessonId}`);
 }
 
 export async function saveLessonKB(lessonId, kb) {
@@ -245,10 +248,10 @@ export async function saveUserLesson(lessonId, markdown) {
 }
 
 export async function getUserLessons() {
-  // Scan cache for all lessons:* keys, or fetch from loadAll
+  // Scan cache for all lessons:* and legacy courses:* keys
   const lessons = [];
   for (const [key, data] of _cache.entries()) {
-    if (key.startsWith('lessons:') && data) {
+    if ((key.startsWith('lessons:') || key.startsWith('courses:')) && data) {
       lessons.push(data);
     }
   }
@@ -256,7 +259,7 @@ export async function getUserLessons() {
 }
 
 export async function getUserLessonMarkdown(lessonId) {
-  const data = await fetchSyncData(`lessons:${lessonId}`);
+  const data = await fetchSyncData(`lessons:${lessonId}`) || await fetchSyncData(`courses:${lessonId}`);
   return data?.markdown || null;
 }
 

--- a/server/dev-sqlite.js
+++ b/server/dev-sqlite.js
@@ -39,6 +39,7 @@ const { generateUserId } = await import('./src/lib/crypto.js');
 const { hashPassword } = await import('./src/lib/password.js');
 const { ADMIN_EMAIL, ADMIN_PASSWORD } = await import('./src/config.js');
 const { seedDefaultContent } = await import('./src/lib/seed.js');
+const { migrateCoursesToLessons } = await import('./src/lib/migrate.js');
 
 const server = new Hono();
 
@@ -67,6 +68,14 @@ if (ADMIN_EMAIL && ADMIN_PASSWORD) {
   } catch (err) {
     console.error('Admin bootstrap failed:', err.message);
   }
+}
+
+// Migrate course → lesson data keys (idempotent)
+try {
+  const migrated = await migrateCoursesToLessons();
+  if (migrated > 0) console.log(`Migrated ${migrated} course → lesson key(s)`);
+} catch (err) {
+  console.error('Migration failed:', err.message);
 }
 
 // Seed/update prompts, lessons on every startup

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -14,6 +14,7 @@ import { generateUserId } from './lib/crypto.js';
 import { hashPassword } from './lib/password.js';
 import { ADMIN_EMAIL, ADMIN_PASSWORD } from './config.js';
 import { seedDefaultContent } from './lib/seed.js';
+import { migrateCoursesToLessons } from './lib/migrate.js';
 
 const server = new Hono();
 
@@ -47,6 +48,13 @@ server.use('*', async (c, next) => {
       } catch (err) {
         console.error('Admin bootstrap failed:', err.message);
       }
+    }
+    // Migrate course → lesson data keys (idempotent)
+    try {
+      const migrated = await migrateCoursesToLessons();
+      if (migrated > 0) console.log(`Migrated ${migrated} course → lesson key(s)`);
+    } catch (err) {
+      console.error('Migration failed (non-fatal):', err.message);
     }
     // Seed/update prompts and lessons
     try {

--- a/server/src/lib/migrate.js
+++ b/server/src/lib/migrate.js
@@ -1,0 +1,86 @@
+/**
+ * Data migration: rename "course" to "lesson" in sync-data keys AND internal data fields.
+ * Runs on server startup. Idempotent — skips if already migrated.
+ */
+
+import db from './db.js';
+
+const KEY_RENAMES = [
+  { from: /^course:/, to: 'lesson:' },
+  { from: /^courseKB:/, to: 'lessonKB:' },
+  { from: /^courses:/, to: 'lessons:' },
+];
+
+function migrateDataFields(data) {
+  if (!data || typeof data !== 'object') return data;
+  if (Array.isArray(data)) {
+    let changed = false;
+    const result = data.map(item => {
+      const migrated = migrateDataFields(item);
+      if (migrated !== item) changed = true;
+      return migrated;
+    });
+    return changed ? result : data;
+  }
+  const renames = {
+    courseId: 'lessonId',
+    courseName: 'lessonName',
+    courseDescription: 'lessonDescription',
+    activeCourses: 'activeLessons',
+    masteredCourses: 'masteredLessons',
+  };
+  const phaseRenames = { course_intro: 'lesson_intro' };
+  let changed = false;
+  const result = {};
+  for (const [key, value] of Object.entries(data)) {
+    const newKey = renames[key] || key;
+    let newValue = value;
+    if (key === 'phase' && typeof value === 'string' && phaseRenames[value]) newValue = phaseRenames[value];
+    if (newValue && typeof newValue === 'object' && !Array.isArray(newValue)) newValue = migrateDataFields(newValue);
+    if (newKey !== key || newValue !== value) changed = true;
+    result[newKey] = newValue;
+  }
+  return changed ? result : data;
+}
+
+export async function migrateCoursesToLessons() {
+  let migrated = 0;
+  const allUsers = new Set(['_system']);
+  try {
+    const users = await db.listUsers?.() || [];
+    for (const u of users) allUsers.add(u.userId);
+  } catch { /* listUsers may not exist on all backends */ }
+
+  for (const userId of allUsers) {
+    let items;
+    try { items = await db.getAllSyncData(userId); } catch { continue; }
+    if (!items?.length) continue;
+
+    for (const item of items) {
+      let newKey = item.dataKey;
+      let keyChanged = false;
+      for (const { from, to } of KEY_RENAMES) {
+        if (from.test(item.dataKey)) {
+          newKey = item.dataKey.replace(from, to);
+          keyChanged = true;
+          break;
+        }
+      }
+      if (keyChanged) {
+        const existing = await db.getSyncData(userId, newKey);
+        if (existing) continue;
+      }
+      const migratedData = migrateDataFields(item.data);
+      const dataChanged = migratedData !== item.data;
+      if (keyChanged) {
+        await db.putSyncData(userId, newKey, migratedData, 0);
+        await db.deleteSyncData(userId, item.dataKey);
+        migrated++;
+      } else if (dataChanged) {
+        await db.putSyncData(userId, item.dataKey, migratedData, item.version);
+        migrated++;
+      }
+    }
+  }
+  return migrated;
+}

--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -375,10 +375,10 @@ admin.put('/v1/admin/prompts/:name', async (c) => {
 admin.get('/v1/admin/lessons', async (c) => {
   const items = await db.getAllSyncData('_system');
   const lessons = items
-    .filter(i => i.dataKey.startsWith('lesson:'))
+    .filter(i => i.dataKey.startsWith('lesson:') || i.dataKey.startsWith('course:'))
     .map(i => ({
-      lessonId: i.dataKey.slice('lesson:'.length),
-      name: i.data.name || i.dataKey.slice('lesson:'.length),
+      lessonId: i.dataKey.replace(/^(lesson:|course:)/, ''),
+      name: i.data.name || i.dataKey.replace(/^(lesson:|course:)/, ''),
       isBuiltIn: i.data.isBuiltIn || false,
       status: i.data.status || 'published',
       createdByName: i.data.createdByName || null,

--- a/server/src/routes/content.js
+++ b/server/src/routes/content.js
@@ -56,9 +56,9 @@ content.get('/v1/prompts/:name', async (c) => {
 content.get('/v1/lessons', async (c) => {
   const items = await db.getAllSyncData('_system');
   const lessons = items
-    .filter(i => i.dataKey.startsWith('lesson:') && i.data.status !== 'draft')
+    .filter(i => (i.dataKey.startsWith('lesson:') || i.dataKey.startsWith('course:')) && i.data.status !== 'draft')
     .map(i => ({
-      lessonId: i.dataKey.slice('lesson:'.length),
+      lessonId: i.dataKey.replace(/^(lesson:|course:)/, ''),
       ...i.data,
       updatedAt: i.updatedAt,
     }));

--- a/server/src/routes/sync.js
+++ b/server/src/routes/sync.js
@@ -7,7 +7,7 @@ const sync = new Hono();
 sync.use('/v1/sync', authenticate);
 sync.use('/v1/sync/*', authenticate);
 
-const VALID_DATA_KEYS = /^(profile|profileSummary|preferences|work|progress:.+|lessonKB:.+|activities:.+|activityKBs:.+|drafts:.+|messages:.+|lessons:.+|onboardingComplete)$/;
+const VALID_DATA_KEYS = /^(profile|profileSummary|preferences|work|progress:.+|lessonKB:.+|courseKB:.+|activities:.+|activityKBs:.+|drafts:.+|messages:.+|lessons:.+|courses:.+|onboardingComplete)$/;
 
 // Keep user record name in sync with extension preferences
 async function syncNameIfNeeded(userId, dataKey, data) {


### PR DESCRIPTION
## Summary

Production data still has `course:*`/`courseKB:*`/`courses:*` keys that were never migrated. This restores the migration script and adds fallback reads.

**Temporary** — migration runs on first cold start, then this will be removed in a follow-up commit.

## Test plan

- [ ] 85 tests pass
- [ ] Deploy to production, migration runs on cold start
- [ ] Existing learner progress loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)