### PR TITLE
Fix compose bar text loss, prod errors, and lesson sorting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Client hot reload: `cd client && npm run dev` (port 5173, proxies API to :3000)
 cd server && npm test
 ```
 
-85 tests. AI route tests mock `ai-provider.js` (not `bedrock.js`).
+87 tests. AI route tests mock `ai-provider.js` (not `bedrock.js`).
 
 ## Deploy to AWS
 

--- a/client/js/lessonOwner.js
+++ b/client/js/lessonOwner.js
@@ -41,6 +41,7 @@ export async function loadLessons() {
     }
   } catch { /* ignore */ }
 
+  lessons.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' }));
   lessonsCache = lessons;
   return lessons;
 }

--- a/client/src/components/chat/ComposeBar.jsx
+++ b/client/src/components/chat/ComposeBar.jsx
@@ -8,9 +8,17 @@ export default function ComposeBar({
   disabled = false,
   allowImages = false,
   elevated = false,
+  text: textProp,
+  onTextChange,
+  image: imageProp,
+  onImageChange,
 }) {
-  const [text, setText] = useState('');
-  const [image, setImage] = useState(null);
+  const [localText, setLocalText] = useState('');
+  const [localImage, setLocalImage] = useState(null);
+  const text = textProp !== undefined ? textProp : localText;
+  const setText = onTextChange || setLocalText;
+  const image = imageProp !== undefined ? imageProp : localImage;
+  const setImage = onImageChange || setLocalImage;
   const inputRef = useRef(null);
   const fileRef = useRef(null);
   const handleResize = useAutoResize();
@@ -26,9 +34,16 @@ export default function ComposeBar({
     onSend(payload);
   };
 
+  const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // Bedrock 5 MB limit
+
   const handleFileChange = (e) => {
     const file = e.target.files?.[0];
     if (!file || !file.type.startsWith('image/')) return;
+    if (file.size > MAX_IMAGE_BYTES) {
+      alert('Image must be under 5 MB.');
+      if (fileRef.current) fileRef.current.value = '';
+      return;
+    }
     const reader = new FileReader();
     reader.onload = () => setImage({ dataUrl: reader.result, name: file.name });
     reader.readAsDataURL(file);

--- a/client/src/lib/lessonEngine.js
+++ b/client/src/lib/lessonEngine.js
@@ -131,9 +131,11 @@ export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream
     await saveScreenshot(imageKey, imageDataUrl);
   }
 
-  // Build conversation tail
+  // Build conversation tail — filter out messages with empty content (e.g. image-only)
   const allMsgs = await getLessonMessages(lessonId);
-  const tail = allMsgs.slice(-15).map(m => ({ role: m.role, content: m.content }));
+  const tail = allMsgs.slice(-15)
+    .map(m => ({ role: m.role, content: m.content }))
+    .filter(m => m.content && (typeof m.content === 'string' ? m.content.trim() : m.content.length));
 
   // Build user message content
   const userParts = [];
@@ -208,7 +210,7 @@ export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream
 
   // Save messages
   const newMessages = [
-    { role: 'user', content: text || '', msgType: MSG_TYPES.USER, phase: LESSON_PHASES.LEARNING,
+    { role: 'user', content: text || (imageKey ? '[image]' : ''), msgType: MSG_TYPES.USER, phase: LESSON_PHASES.LEARNING,
       metadata: imageKey ? { imageKey } : null, timestamp: ts() },
     { role: 'assistant', content: parsed.text, msgType: MSG_TYPES.GUIDE,
       phase: achieved ? LESSON_PHASES.COMPLETED : LESSON_PHASES.LEARNING, timestamp: ts() },

--- a/client/src/pages/LessonChat.jsx
+++ b/client/src/pages/LessonChat.jsx
@@ -48,6 +48,8 @@ export default function LessonChat() {
   const headerRef = useRef(null);
   const [composePinned, setComposePinned] = useState(true);
   const composeAnchorRef = useRef(null);
+  const [composeText, setComposeText] = useState('');
+  const [composeImage, setComposeImage] = useState(null);
 
   // Pin header when its top edge reaches the viewport top
   useEffect(() => {
@@ -306,6 +308,10 @@ export default function LessonChat() {
             onSend={handleSend}
             disabled={busy}
             allowImages
+            text={composeText}
+            onTextChange={setComposeText}
+            image={composeImage}
+            onImageChange={setComposeImage}
           />
         </div>
       )}
@@ -319,6 +325,10 @@ export default function LessonChat() {
             disabled={busy}
             allowImages
             elevated
+            text={composeText}
+            onTextChange={setComposeText}
+            image={composeImage}
+            onImageChange={setComposeImage}
           />
         </div>
       )}

--- a/server/src/routes/ai.js
+++ b/server/src/routes/ai.js
@@ -14,6 +14,13 @@ aiRoute.post('/v1/ai/messages', async (c) => {
   if (!model) return c.json({ error: 'model is required' }, 400);
   if (!messages || !Array.isArray(messages)) return c.json({ error: 'messages array is required' }, 400);
 
+  // Reject messages with empty content — Bedrock returns ValidationException for these
+  for (const msg of messages) {
+    if (!msg.content || (typeof msg.content === 'string' && !msg.content.trim()) || (Array.isArray(msg.content) && msg.content.length === 0)) {
+      return c.json({ error: 'messages must have non-empty content' }, 400);
+    }
+  }
+
   const aiBody = {
     max_tokens: max_tokens || 1024,
     ...(system ? { system } : {}),

--- a/server/tests/routes/ai.test.js
+++ b/server/tests/routes/ai.test.js
@@ -98,6 +98,28 @@ describe('POST /v1/ai/messages', () => {
     assert.equal(res.status, 401);
   });
 
+  it('returns 400 when a message has empty string content', async () => {
+    const app = new Hono();
+    app.route('/', ai);
+    const res = await authedReq(app, 'POST', '/v1/ai/messages', {
+      model: 'claude-haiku-4-5-20251001',
+      messages: [{ role: 'user', content: '' }],
+    });
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error, 'messages must have non-empty content');
+  });
+
+  it('returns 400 when a message has empty array content', async () => {
+    const app = new Hono();
+    app.route('/', ai);
+    const res = await authedReq(app, 'POST', '/v1/ai/messages', {
+      model: 'claude-haiku-4-5-20251001',
+      messages: [{ role: 'user', content: [] }],
+    });
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error, 'messages must have non-empty content');
+  });
+
   it('omits system from body when not provided', async () => {
     let receivedBody;
     aiProvider.invoke = async (model, body) => {


### PR DESCRIPTION
## Summary
- **Compose bar text loss:** Lifted text/image state from ComposeBar to LessonChat so inline and fixed-position compose bars share state. Previously, scroll events toggled `composePinned`, unmounting/remounting the active bar and destroying the user's typed text.
- **Empty message error (prod):** Bedrock was rejecting `user messages must have non-empty content` when image-only messages were saved with `content: ''` and later replayed in the conversation tail. Now filters empty messages from tail and saves `'[image]'` placeholder. Added server-side 400 validation as a safety net.
- **Image size error (prod):** Added client-side 5 MB file size check before upload — Bedrock rejects images over 5 MB.
- **Lesson sorting:** Lessons now sorted alphabetically (1-9, a-z) in `loadLessons()`.

## Test plan
- [x] 87/87 server tests pass (2 new tests for empty message validation)
- [ ] Verify compose bar retains text when scrolling up/down during a lesson
- [ ] Verify image-only messages work without errors
- [ ] Verify images over 5 MB are rejected with a user-friendly message
- [ ] Verify lessons appear sorted alphabetically in both classroom and admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)