### PR TITLE
Sort lessons alphabetically in server API responses

### DIFF
--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -383,7 +383,8 @@ admin.get('/v1/admin/lessons', async (c) => {
       status: i.data.status || 'published',
       createdByName: i.data.createdByName || null,
       updatedAt: i.updatedAt,
-    }));
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' }));
   return c.json(lessons);
 });
 

--- a/server/src/routes/content.js
+++ b/server/src/routes/content.js
@@ -61,7 +61,8 @@ content.get('/v1/lessons', async (c) => {
       lessonId: i.dataKey.slice('lesson:'.length),
       ...i.data,
       updatedAt: i.updatedAt,
-    }));
+    }))
+    .sort((a, b) => (a.name || '').localeCompare(b.name || '', undefined, { numeric: true, sensitivity: 'base' }));
   return c.json(lessons);
 });
 


### PR DESCRIPTION
## Summary
- Sort `/v1/lessons` and `/v1/admin/lessons` responses alphabetically (numeric-aware)
- The previous fix only sorted client-side in `loadLessons()`, which doesn't apply to admin pages that fetch directly from the API

## Test plan
- [x] 87/87 server tests pass
- [ ] Verify admin Lessons page shows lessons in alphabetical order
- [ ] Verify classroom lessons list is sorted

🤖 Generated with [Claude Code](https://claude.com/claude-code)