### PR TITLE
Clarify lesson-creator prompt: no separate prompt-writing step

### DIFF
--- a/client/prompts/lesson-creator.md
+++ b/client/prompts/lesson-creator.md
@@ -134,6 +134,7 @@ In EVERY response, weave in a natural sense of where things stand. Don't just as
 - When the user seems to want to rush: "A well-designed lesson produces better activities and assessments. Let's make sure the foundation is solid."
 - If the user proposes more than 4 objectives, push back: "For a 20-minute lesson, you need 2-4 focused objectives. Which ones are essential to the exemplar? Let's cut the rest or combine them."
 - Always end with a specific, actionable question or statement that moves the conversation forward.
+- Never describe a separate prompt-writing step. The conversation IS the lesson design process — clicking "Create Lesson" extracts everything automatically.
 - If the admin describes activities involving video uploads, audio recording, file attachments, link sharing, code execution, or any input besides text and images — stop and redirect: "plato only supports text and image uploads right now. Let's design this so learners can demonstrate it through writing or screenshots."
 
 ## Readiness signal
@@ -159,9 +160,9 @@ Sometimes a user will present an existing lesson markdown and ask to edit it. Wh
 4. **Apply the same rigor.** Edits to the exemplar should cascade to objectives. New objectives must still be assessable and coherent with the exemplar. The same 2-4 objective limit and ~20 minute scope apply.
 5. **When the user is done editing,** let them know they can hit "Update Lesson" to save the changes. The same readiness thresholds apply.
 
-## When the user clicks "Create Lesson" or "Update Lesson"
+## IMPORTANT: What happens when the user clicks "Create Lesson" or "Update Lesson"
 
-The system extracts the lesson markdown automatically from the conversation — you do not need to generate it. Just keep coaching until the readiness signal indicates the lesson is ready.
+When the user clicks the button, the system automatically extracts the lesson (exemplar + objectives) from this conversation. There is NO separate prompt-writing step. The user does NOT need to write or paste anything — the conversation IS the design process. Never tell the user they will be "asked to write" or "need to enter" a prompt. Just coach them through the design and tell them to click the button when ready.
 
 ## Response format
 


### PR DESCRIPTION
## Summary
- The lesson-creator agent was telling admins they'd be "asked to write a lesson prompt" after clicking Create Lesson — this step doesn't exist
- Strengthened the prompt section about Create Lesson to emphasize extraction is automatic
- Added explicit rule: never describe a separate prompt-writing step

## Test plan
- [x] 87/87 server tests pass
- [ ] Create a new lesson via admin and verify the agent doesn't mention a manual prompt-writing step

🤖 Generated with [Claude Code](https://claude.com/claude-code)