### PR TITLE
Auto-save lesson and KB editor conversations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Client hot reload: `cd client && npm run dev` (port 5173, proxies API to :3000)
 cd server && npm test
 ```
 
-87 tests. AI route tests mock `ai-provider.js` (not `bedrock.js`).
+90 tests. AI route tests mock `ai-provider.js` (not `bedrock.js`).
 
 ## Deploy to AWS
 

--- a/client/src/pages/admin/AdminCustomizer.jsx
+++ b/client/src/pages/admin/AdminCustomizer.jsx
@@ -40,6 +40,8 @@ export default function AdminCustomizer() {
 
   // KB state
   const [kbContent, setKbContent] = useState('');
+  const [kbConversation, setKbConversation] = useState(null);
+  const [kbReadiness, setKbReadiness] = useState(null);
   const [kbUpdatedAt, setKbUpdatedAt] = useState(null);
   const [kbUpdatedByName, setKbUpdatedByName] = useState(null);
   const [kbEditing, setKbEditing] = useState(isEditKBRoute);
@@ -62,6 +64,8 @@ export default function AdminCustomizer() {
       setLogoBase64(themeData.logoBase64 || null);
       setClassroomName(themeData.classroomName || '');
       setKbContent(kbData.content || '');
+      setKbConversation(kbData.conversation || null);
+      setKbReadiness(kbData.readiness ?? null);
       setKbUpdatedAt(kbData.updatedAt || null);
       setKbUpdatedByName(kbData.updatedByName || null);
     } catch { /* ignore */ }
@@ -203,6 +207,8 @@ export default function AdminCustomizer() {
           {kbEditing ? (
             <KBEditor
               initialContent={kbContent}
+              initialConversation={kbConversation}
+              initialReadiness={kbReadiness}
               onSave={async (content, conversation, readiness) => {
                 await adminApi('PUT', '/v1/admin/knowledge-base', { content, conversation, readiness });
                 const fresh = await adminApi('GET', '/v1/admin/knowledge-base');
@@ -272,16 +278,25 @@ function KBViewer({ content, updatedAt, updatedByName, onEdit }) {
 
 // -- KB Editor (conversational AI editor) -------------------------------------
 
-function KBEditor({ initialContent, onSave, onCancel }) {
+function KBEditor({ initialContent, onSave, onCancel, initialConversation, initialReadiness }) {
   const isEditing = !!initialContent;
-  const [chatMessages, setChatMessages] = useState([]);
-  const [readiness, setReadiness] = useState(0);
+  const [chatMessages, setChatMessages] = useState(initialConversation || []);
+  const [readiness, setReadiness] = useState(initialReadiness ?? 0);
   const [busy, setBusy] = useState('');
   const [error, setError] = useState('');
 
   const [streamingText, setStreamingText] = useState(null);
   const displayText = useStreamedText(streamingText);
   const pendingRef = useRef(null);
+
+  // Auto-save KB conversation after each exchange
+  const readinessRef = useRef(readiness);
+  useEffect(() => { readinessRef.current = readiness; }, [readiness]);
+  useEffect(() => {
+    if (chatMessages.length === 0) return;
+    const conversation = chatMessages.map(m => ({ role: m.role, content: m.content, msgType: m.msgType }));
+    adminApi('PUT', '/v1/admin/knowledge-base/conversation', { conversation, readiness: readinessRef.current }).catch(() => {});
+  }, [chatMessages]);
 
   useEffect(() => {
     if (displayText === null && pendingRef.current) {
@@ -293,8 +308,9 @@ function KBEditor({ initialContent, onSave, onCancel }) {
     }
   }, [displayText]);
 
-  // Start conversation
+  // Start conversation — skip if resuming from a saved conversation
   useEffect(() => {
+    if (initialConversation?.length) return;
     let cancelled = false;
     setBusy('starting');
     setStreamingText('');

--- a/client/src/pages/admin/AdminLessons.jsx
+++ b/client/src/pages/admin/AdminLessons.jsx
@@ -105,12 +105,14 @@ export default function AdminLessons() {
         onSave={async (name, markdown, conversation, readiness) => {
           const lessonId = name.trim().replace(/\s+/g, '-').toLowerCase();
           await adminApi('PUT', `/v1/admin/lessons/${encodeURIComponent(lessonId)}`, { markdown, name, status: 'draft', conversation, readiness });
+          adminApi('DELETE', '/v1/admin/draft-conversation').catch(() => {});
           setMessage({ text: 'Lesson saved as draft.', type: 'success' });
           await loadLessons();
           navigate('/plato/lessons');
         }}
         onCancel={() => navigate('/plato/lessons')}
         onError={(text) => setMessage({ text, type: 'error' })}
+        loadDraft
       />
     );
   }
@@ -229,7 +231,7 @@ export default function AdminLessons() {
 
 // -- Lesson creation/editing view with AI Chat --------------------------------
 
-function NewLessonView({ onSave, onCancel, onError, editingLessonId, initialMessages, initialReadiness, needsAgentReply }) {
+function NewLessonView({ onSave, onCancel, onError, editingLessonId, initialMessages, initialReadiness, needsAgentReply, loadDraft }) {
   const isEditing = !!editingLessonId;
   useEffect(() => { document.title = isEditing ? 'Edit Lesson — Admin' : 'New Lesson — Admin'; }, [isEditing]);
   const [chatMessages, setChatMessages] = useState(initialMessages || []);
@@ -237,11 +239,26 @@ function NewLessonView({ onSave, onCancel, onError, editingLessonId, initialMess
   const [busy, setBusy] = useState('');
   const [error, setError] = useState('');
   const [key, setKey] = useState(0); // increment to restart conversation
+  const [draftLoaded, setDraftLoaded] = useState(!loadDraft); // skip loading if not needed
 
   // Streaming
   const [streamingText, setStreamingText] = useState(null);
   const displayText = useStreamedText(streamingText);
   const pendingRef = useRef(null);
+
+  // Auto-save conversation after each exchange
+  const readinessRef = useRef(readiness);
+  useEffect(() => { readinessRef.current = readiness; }, [readiness]);
+  useEffect(() => {
+    if (chatMessages.length === 0) return;
+    const conversation = chatMessages.map(m => ({ role: m.role, content: m.content, msgType: m.msgType }));
+    const r = readinessRef.current;
+    if (isEditing) {
+      adminApi('PUT', `/v1/admin/lessons/${encodeURIComponent(editingLessonId)}/conversation`, { conversation, readiness: r }).catch(() => {});
+    } else {
+      adminApi('PUT', '/v1/admin/draft-conversation', { conversation, readiness: r }).catch(() => {});
+    }
+  }, [chatMessages, isEditing, editingLessonId]);
 
   // Handle stream drain completing
   useEffect(() => {
@@ -254,14 +271,34 @@ function NewLessonView({ onSave, onCancel, onError, editingLessonId, initialMess
     }
   }, [displayText]);
 
+  // Load draft conversation for new lessons (if one exists from a previous session)
+  useEffect(() => {
+    if (!loadDraft) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await adminApi('GET', '/v1/admin/draft-conversation');
+        if (!cancelled && data.conversation?.length) {
+          setChatMessages(data.conversation);
+          setReadiness(data.readiness ?? 0);
+        }
+      } catch { /* no draft */ }
+      if (!cancelled) setDraftLoaded(true);
+    })();
+    return () => { cancelled = true; };
+  }, [loadDraft]);
+
   // Start conversation on mount (and on key change after lesson creation)
   // Skip when resuming an existing conversation that already has an agent reply
   const skipInitRef = useRef(!!initialMessages?.length && !needsAgentReply);
   useEffect(() => {
+    if (!draftLoaded) return; // wait for draft check to complete
     if (skipInitRef.current) {
       skipInitRef.current = false;
       return;
     }
+    // If we loaded a draft, skip the initial agent call — conversation is already populated
+    if (chatMessages.length > 0 && key === 0) return;
     let cancelled = false;
 
     // Determine the opening message(s) to send to the agent
@@ -276,6 +313,9 @@ function NewLessonView({ onSave, onCancel, onError, editingLessonId, initialMess
     setBusy('starting');
     setStreamingText('');
     setError('');
+
+    // Clear draft when starting fresh
+    if (!isEditing) adminApi('DELETE', '/v1/admin/draft-conversation').catch(() => {});
 
     (async () => {
       try {
@@ -296,7 +336,7 @@ function NewLessonView({ onSave, onCancel, onError, editingLessonId, initialMess
     })();
 
     return () => { cancelled = true; };
-  }, [key]);
+  }, [key, draftLoaded]);
 
   // Keep a ref to chatMessages so handleSend always has the latest
   const chatMessagesRef = useRef(chatMessages);

--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -428,6 +428,43 @@ admin.put('/v1/admin/lessons/:lessonId', async (c) => {
   return c.json({ lessonId, ok: true });
 });
 
+// PUT /v1/admin/lessons/:lessonId/conversation — auto-save conversation without requiring markdown
+admin.put('/v1/admin/lessons/:lessonId/conversation', async (c) => {
+  const lessonId = c.req.param('lessonId');
+  const body = await c.req.json();
+  const current = await db.getSyncData('_system', `lesson:${lessonId}`);
+  if (!current) return c.json({ error: 'Lesson not found' }, 404);
+  const data = { ...current.data };
+  data.conversation = body.conversation || null;
+  if (body.readiness !== undefined) data.readiness = body.readiness;
+  await db.putSyncData('_system', `lesson:${lessonId}`, data, current.version);
+  return c.json({ ok: true });
+});
+
+// PUT /v1/admin/draft-conversation — auto-save new lesson conversation (before lesson exists)
+admin.put('/v1/admin/draft-conversation', async (c) => {
+  const body = await c.req.json();
+  const current = await db.getSyncData('_system', 'draft:lesson-conversation');
+  await db.putSyncData('_system', 'draft:lesson-conversation', {
+    conversation: body.conversation || null,
+    readiness: body.readiness ?? 0,
+  }, current?.version || 0);
+  return c.json({ ok: true });
+});
+
+// GET /v1/admin/draft-conversation — resume new lesson conversation
+admin.get('/v1/admin/draft-conversation', async (c) => {
+  const item = await db.getSyncData('_system', 'draft:lesson-conversation');
+  if (!item?.data?.conversation?.length) return c.json({ conversation: null, readiness: 0 });
+  return c.json({ conversation: item.data.conversation, readiness: item.data.readiness ?? 0 });
+});
+
+// DELETE /v1/admin/draft-conversation — clear draft after lesson is created
+admin.delete('/v1/admin/draft-conversation', async (c) => {
+  await db.deleteSyncData('_system', 'draft:lesson-conversation');
+  return c.json({ ok: true });
+});
+
 // DELETE /v1/admin/lessons/:lessonId
 admin.delete('/v1/admin/lessons/:lessonId', async (c) => {
   const lessonId = c.req.param('lessonId');
@@ -464,6 +501,20 @@ admin.put('/v1/admin/knowledge-base', async (c) => {
   await db.putSyncData('_system', 'knowledgeBase', {
     content: body.content,
     conversation: body.conversation !== undefined ? body.conversation : (current?.data?.conversation || null),
+    readiness: body.readiness !== undefined ? body.readiness : (current?.data?.readiness ?? null),
+    updatedBy: adminUser.userId,
+  }, current?.version || 0);
+  return c.json({ ok: true });
+});
+
+// PUT /v1/admin/knowledge-base/conversation — auto-save KB editor conversation
+admin.put('/v1/admin/knowledge-base/conversation', async (c) => {
+  const body = await c.req.json();
+  const current = await db.getSyncData('_system', 'knowledgeBase');
+  const adminUser = c.get('user');
+  await db.putSyncData('_system', 'knowledgeBase', {
+    content: current?.data?.content || '',
+    conversation: body.conversation || null,
     readiness: body.readiness !== undefined ? body.readiness : (current?.data?.readiness ?? null),
     updatedBy: adminUser.userId,
   }, current?.version || 0);

--- a/server/tests/routes/admin.test.js
+++ b/server/tests/routes/admin.test.js
@@ -229,6 +229,69 @@ Produce a thing.
   });
 });
 
+describe('PUT /v1/admin/lessons/:lessonId/conversation — auto-save', () => {
+  beforeEach(() => {
+    db.getUserById = async () => ({ userId: 'usr_admin', role: 'admin', name: 'Admin' });
+  });
+
+  it('saves conversation to existing lesson without touching markdown', async () => {
+    const existing = { markdown: '# Test\n\nDesc\n\n## Exemplar\n\nDo it\n\n## Learning Objectives\n\n- Can do A\n- Can do B', name: 'Test', status: 'published' };
+    db.getSyncData = async () => ({ data: existing, version: 1 });
+    let savedData;
+    db.putSyncData = async (uid, key, data) => { savedData = data; };
+    const app = new Hono(); app.route('/', admin);
+    const convo = [{ role: 'user', content: 'hi' }, { role: 'assistant', content: 'hello' }];
+    const res = await adminReq(app, 'PUT', '/v1/admin/lessons/test/conversation', { conversation: convo, readiness: 5 });
+    assert.equal(res.status, 200);
+    assert.deepEqual(savedData.conversation, convo);
+    assert.equal(savedData.readiness, 5);
+    assert.equal(savedData.markdown, existing.markdown, 'markdown must not be modified');
+    assert.equal(savedData.status, 'published', 'status must not be modified');
+  });
+
+  it('returns 404 for non-existent lesson', async () => {
+    db.getSyncData = async () => null;
+    const app = new Hono(); app.route('/', admin);
+    const res = await adminReq(app, 'PUT', '/v1/admin/lessons/nope/conversation', { conversation: [] });
+    assert.equal(res.status, 404);
+  });
+});
+
+describe('draft conversation endpoints', () => {
+  beforeEach(() => {
+    db.getUserById = async () => ({ userId: 'usr_admin', role: 'admin', name: 'Admin' });
+  });
+
+  it('saves and retrieves a draft conversation', async () => {
+    let stored = null;
+    db.getSyncData = async () => stored ? { data: stored, version: 1 } : null;
+    db.putSyncData = async (uid, key, data) => { stored = data; };
+    db.deleteSyncData = async () => { stored = null; };
+    const app = new Hono(); app.route('/', admin);
+
+    // Save draft
+    const convo = [{ role: 'user', content: 'new lesson' }];
+    const putRes = await adminReq(app, 'PUT', '/v1/admin/draft-conversation', { conversation: convo, readiness: 3 });
+    assert.equal(putRes.status, 200);
+
+    // Get draft
+    const getRes = await adminReq(app, 'GET', '/v1/admin/draft-conversation');
+    assert.equal(getRes.status, 200);
+    const data = await getRes.json();
+    assert.deepEqual(data.conversation, convo);
+    assert.equal(data.readiness, 3);
+
+    // Delete draft
+    const delRes = await adminReq(app, 'DELETE', '/v1/admin/draft-conversation');
+    assert.equal(delRes.status, 200);
+
+    // Get after delete returns null
+    const emptyRes = await adminReq(app, 'GET', '/v1/admin/draft-conversation');
+    const emptyData = await emptyRes.json();
+    assert.equal(emptyData.conversation, null);
+  });
+});
+
 describe('GET /v1/admin/stats/lessons', () => {
   beforeEach(() => {
     db.getUserById = async () => ({ userId: 'usr_admin', role: 'admin', name: 'Admin' });


### PR DESCRIPTION
## Summary
- Auto-save lesson creator and KB editor conversations after each message exchange
- Previously, all conversation progress was lost if the admin navigated away before clicking Create/Update
- New server endpoints save only conversation/readiness without touching markdown, status, or other lesson data
- Draft conversations for new lessons stored under a separate key (`draft:lesson-conversation`) so they never appear in the lesson list
- Existing lessons and KB are fully safe — auto-save only touches the conversation field

## Test plan
- [x] 90/90 server tests pass (3 new tests for conversation auto-save endpoints)
- [ ] Start a new lesson creation, navigate away, return to /plato/lessons/new — conversation should resume
- [ ] Edit an existing lesson, navigate away, click edit again — conversation should resume
- [ ] Open KB editor, navigate away, re-open — conversation should resume
- [ ] Verify creating a lesson still works end-to-end (draft cleared after creation)
- [ ] Verify existing lessons and KB content are not modified by auto-save

🤖 Generated with [Claude Code](https://claude.com/claude-code)