### PR TITLE
Fix lesson messages being overwritten on every exchange

### DIFF
--- a/client/js/storage.js
+++ b/client/js/storage.js
@@ -229,9 +229,12 @@ export async function saveLessonMessage(lessonId, msg) {
 
 export async function saveLessonMessages(lessonId, msgs) {
   const key = `messages:${lessonId}`;
+  let all = _cache.get(key);
+  if (!Array.isArray(all)) all = await getLessonMessages(lessonId);
   const withTimestamps = msgs.map(m => ({ ...m, timestamp: m.timestamp || Date.now() }));
-  _cache.set(key, withTimestamps);
-  await putSyncData(key, withTimestamps);
+  all = [...all, ...withTimestamps];
+  _cache.set(key, all);
+  await putSyncData(key, all);
 }
 
 export async function clearLessonMessages(lessonId) {


### PR DESCRIPTION
## Summary
- `saveLessonMessages()` was **replacing** the entire message history with only the newest messages instead of **appending** to it
- On every exchange, only the latest user + assistant messages survived — all prior conversation history was destroyed
- Now loads existing messages first and appends, matching the behavior of `saveLessonMessage()` (singular)

## Test plan
- [x] 90/90 server tests pass
- [ ] Start a lesson, send 3+ messages, refresh — all messages should persist
- [ ] Resume a lesson after navigating away — full conversation visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)