### PR TITLE
Auto-scroll chat and position compose above footer

### DIFF
--- a/client/src/components/chat/ChatArea.jsx
+++ b/client/src/components/chat/ChatArea.jsx
@@ -1,58 +1,13 @@
 import { useRef, useEffect, forwardRef } from 'react';
 
-const NEAR_BOTTOM_PX = 150; // accounts for fixed compose bar + spacer
-
-const ChatArea = forwardRef(function ChatArea({ children, lessonName }, ref) {
+const ChatArea = forwardRef(function ChatArea({ children, lessonName, scrollTrigger }, ref) {
   const localRef = useRef(null);
   const scrollRef = ref || localRef;
-  const programmaticScroll = useRef(false);
-  const nearBottomRef = useRef(true);
+  const bottomRef = useRef(null);
 
   useEffect(() => {
-    const el = typeof scrollRef === 'function' ? null : scrollRef.current;
-    if (!el) return;
-
-    // Find the scroll container — could be the element itself or a parent
-    let scrollContainer = document.documentElement;
-    let sc = el;
-    while (sc && sc !== document.documentElement) {
-      const { overflowY } = getComputedStyle(sc);
-      if (overflowY === 'auto' || overflowY === 'scroll') {
-        scrollContainer = sc;
-        break;
-      }
-      sc = sc.parentElement;
-    }
-
-    function isNearBottom() {
-      return scrollContainer.scrollHeight - scrollContainer.scrollTop - scrollContainer.clientHeight < NEAR_BOTTOM_PX;
-    }
-
-    function scrollToBottom() {
-      programmaticScroll.current = true;
-      scrollContainer.scrollTop = scrollContainer.scrollHeight;
-    }
-
-    function handleScroll() {
-      if (programmaticScroll.current) {
-        programmaticScroll.current = false;
-        return;
-      }
-      nearBottomRef.current = isNearBottom();
-    }
-
-    const observer = new MutationObserver(() => {
-      if (nearBottomRef.current) scrollToBottom();
-    });
-
-    observer.observe(el, { childList: true, subtree: true, characterData: true });
-    scrollContainer.addEventListener('scroll', handleScroll);
-
-    return () => {
-      observer.disconnect();
-      scrollContainer.removeEventListener('scroll', handleScroll);
-    };
-  }, [scrollRef]);
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [scrollTrigger]);
 
   return (
     <div
@@ -65,6 +20,7 @@ const ChatArea = forwardRef(function ChatArea({ children, lessonName }, ref) {
       <div className="mx-auto max-w-3xl space-y-3">
         {children}
       </div>
+      <div ref={bottomRef} aria-hidden="true" />
     </div>
   );
 });

--- a/client/src/pages/LessonChat.jsx
+++ b/client/src/pages/LessonChat.jsx
@@ -289,7 +289,7 @@ export default function LessonChat() {
       </div>
 
       <div className="flex-1">
-      <ChatArea lessonName={lesson?.name}>
+      <ChatArea lessonName={lesson?.name} scrollTrigger={`${messages.length}-${displayText?.length ?? ''}`}>
         {messages.map(renderMessage)}
         {displayText != null && displayText.length > 0 && (
           <AssistantMessage content={displayText} />
@@ -318,7 +318,7 @@ export default function LessonChat() {
 
       {/* Fixed compose overlay — interactive when pinned */}
       {phase && composePinned && (
-        <div className="fixed bottom-0 left-0 right-0 z-50">
+        <div className="fixed bottom-9 left-0 right-0 z-50">
           <ComposeBar
             placeholder={phase === LESSON_PHASES.COMPLETED ? "Continue chatting..." : "Chat with your coach..."}
             onSend={handleSend}


### PR DESCRIPTION
## Summary
- Replace MutationObserver auto-scroll with React-driven `scrollTrigger` prop — scrolls to bottom when messages are added or streaming text updates
- Position fixed compose bar above footer (`bottom-9` instead of `bottom-0`)

## Test plan
- [x] 90 server tests, 21 client tests pass
- [ ] New messages and streaming responses auto-scroll into view
- [ ] Compose bar sits above footer, not overlapping it

🤖 Generated with [Claude Code](https://claude.com/claude-code)