### PR TITLE
Add request timeout to Bedrock streaming invocations

### DIFF
--- a/server/src/lib/ai-provider.js
+++ b/server/src/lib/ai-provider.js
@@ -11,6 +11,10 @@
 const provider = process.env.AI_PROVIDER
   || (process.env.ANTHROPIC_API_KEY ? 'anthropic' : 'bedrock');
 
+// Timeout for Bedrock requests — set just under the Lambda function timeout
+// (60 s) so errors propagate cleanly rather than causing a hard Lambda kill.
+const BEDROCK_TIMEOUT_MS = 55_000;
+
 let ai;
 
 if (provider === 'anthropic') {
@@ -84,29 +88,41 @@ if (provider === 'anthropic') {
   ai = {
     async invoke(model, body) {
       const modelId = MODEL_MAP[model] || model;
-      const command = new InvokeModelCommand({
-        modelId,
-        contentType: 'application/json',
-        accept: 'application/json',
-        body: JSON.stringify({ anthropic_version: 'bedrock-2023-05-31', ...body }),
-      });
-      const response = await client.send(command);
-      return JSON.parse(new TextDecoder().decode(response.body));
+      const abortController = new AbortController();
+      const timer = setTimeout(() => abortController.abort(new Error(`Bedrock invoke timed out after ${BEDROCK_TIMEOUT_MS}ms`)), BEDROCK_TIMEOUT_MS);
+      try {
+        const command = new InvokeModelCommand({
+          modelId,
+          contentType: 'application/json',
+          accept: 'application/json',
+          body: JSON.stringify({ anthropic_version: 'bedrock-2023-05-31', ...body }),
+        });
+        const response = await client.send(command, { abortSignal: abortController.signal });
+        return JSON.parse(new TextDecoder().decode(response.body));
+      } finally {
+        clearTimeout(timer);
+      }
     },
 
     async *invokeStream(model, body) {
       const modelId = MODEL_MAP[model] || model;
-      const command = new InvokeModelWithResponseStreamCommand({
-        modelId,
-        contentType: 'application/json',
-        accept: 'application/json',
-        body: JSON.stringify({ anthropic_version: 'bedrock-2023-05-31', ...body }),
-      });
-      const response = await client.send(command);
-      for await (const event of response.body) {
-        if (event.chunk) {
-          yield JSON.parse(new TextDecoder().decode(event.chunk.bytes));
+      const abortController = new AbortController();
+      const timer = setTimeout(() => abortController.abort(new Error(`Bedrock stream timed out after ${BEDROCK_TIMEOUT_MS}ms`)), BEDROCK_TIMEOUT_MS);
+      try {
+        const command = new InvokeModelWithResponseStreamCommand({
+          modelId,
+          contentType: 'application/json',
+          accept: 'application/json',
+          body: JSON.stringify({ anthropic_version: 'bedrock-2023-05-31', ...body }),
+        });
+        const response = await client.send(command, { abortSignal: abortController.signal });
+        for await (const event of response.body) {
+          if (event.chunk) {
+            yield JSON.parse(new TextDecoder().decode(event.chunk.bytes));
+          }
         }
+      } finally {
+        clearTimeout(timer);
       }
     },
   };


### PR DESCRIPTION
## Motivation

CloudWatch shows a 60,000 ms Lambda timeout on `plato-PlatoStreamFunction`. The Bedrock `invokeStream` call has no client-side timeout, so when Bedrock is slow the Lambda hangs until AWS kills it at the configured limit. This causes a hard connection drop for the learner (no error message, just a broken stream), which likely prompts retries and contributes to the elevated over-target rate (56.2% on-target, yellow zone).

Adding an `AbortSignal` timeout of 55 seconds (just under the Lambda limit) lets the error propagate cleanly through the SSE error path — the client receives a proper `{type:'error'}` event and can surface a retry prompt instead of hanging indefinitely.

The same guard is added to `invoke` (non-streaming) for consistency, using the same 55 s ceiling.

## Changes

- `server/src/lib/ai-provider.js`: wrap `InvokeModelWithResponseStreamCommand` and `InvokeModelCommand` Bedrock calls with an `AbortController` that fires after 55 s, so timeouts surface as catchable errors rather than silent Lambda kills.

---
*Proposed by [plato-pilot](https://github.com/UIC-OSF/plato-pilot) — automated KPI-driven suggestions*