### PR TITLE
Add request timeout to Bedrock AI calls to prevent Lambda timeouts

### DIFF
--- a/server/src/lib/ai-provider.js
+++ b/server/src/lib/ai-provider.js
@@ -81,6 +81,10 @@ if (provider === 'anthropic') {
     'claude-sonnet-4-6': 'us.anthropic.claude-sonnet-4-6',
   };
 
+  // Abort timeout in ms — set below Lambda's 60s limit so we get a clean error
+  // frame to the client rather than a hard Lambda timeout disconnect.
+  const BEDROCK_TIMEOUT_MS = 55_000;
+
   ai = {
     async invoke(model, body) {
       const modelId = MODEL_MAP[model] || model;
@@ -90,7 +94,9 @@ if (provider === 'anthropic') {
         accept: 'application/json',
         body: JSON.stringify({ anthropic_version: 'bedrock-2023-05-31', ...body }),
       });
-      const response = await client.send(command);
+      const response = await client.send(command, {
+        abortSignal: AbortSignal.timeout(BEDROCK_TIMEOUT_MS),
+      });
       return JSON.parse(new TextDecoder().decode(response.body));
     },
 
@@ -102,7 +108,9 @@ if (provider === 'anthropic') {
         accept: 'application/json',
         body: JSON.stringify({ anthropic_version: 'bedrock-2023-05-31', ...body }),
       });
-      const response = await client.send(command);
+      const response = await client.send(command, {
+        abortSignal: AbortSignal.timeout(BEDROCK_TIMEOUT_MS),
+      });
       for await (const event of response.body) {
         if (event.chunk) {
           yield JSON.parse(new TextDecoder().decode(event.chunk.bytes));


### PR DESCRIPTION
## Motivation

CloudWatch logs show a Lambda timeout at exactly 60,000ms on `PlatoStreamFunction` — the streaming AI function hit the hard Lambda execution limit, meaning a Bedrock call hung for the full 60 seconds before being killed. This leaves the learner with a broken, hung lesson UI and no error feedback.

The `ai-provider.js` Bedrock `invoke` and `invokeStream` paths currently have no request-level timeout. Adding `AbortSignal.timeout()` to both Bedrock commands means the call will abort cleanly at 55s (just before Lambda's limit), allowing the streaming route's existing `catch` block to write a proper SSE error frame to the client instead of a hard disconnect.

## Changes

- Added `AbortSignal.timeout(55_000)` to the `InvokeModelCommand` (buffered) call in Bedrock `invoke()`
- Added `AbortSignal.timeout(55_000)` to the `InvokeModelWithResponseStreamCommand` (streaming) call in Bedrock `invokeStream()`
- No changes to the Anthropic provider path (it has its own network timeout behavior)
- No breaking changes — timeout errors surface as thrown exceptions, which the existing error handlers in `ai.js` already catch and forward as SSE error events to the client

---
*Proposed by [plato-pilot](https://github.com/UIC-OSF/plato-pilot) — automated KPI-driven suggestions*