### PR TITLE
Revert unreviewed pilot commit; require pilot to use a branch

### DIFF
--- a/.github/workflows/pilot.yml
+++ b/.github/workflows/pilot.yml
@@ -62,14 +62,19 @@ jobs:
             If nothing is actionable, stop immediately — do not invent work.
 
             ## Step 3: Implement (≤15 turns)
+            - BEFORE editing any file, create a working branch:
+              `BRANCH="pilot/$(date +%Y-%m-%d)-<short-slug>" && git checkout -b "$BRANCH"`
+            - Do NOT commit directly to main under any circumstances. If `gh pr create` fails
+              with "you must first push the current branch to a remote," STOP — do not push
+              to main. Start over on a branch.
             - Read only the files you need to change
             - Make exactly ONE focused change
             - No breaking changes, data migrations, or large refactors
 
             ## Step 4: Verify and ship (≤5 turns)
             - Run `cd server && npm ci && npm test` — all tests must pass
-            - Create a PR:
+            - Commit on your branch, then push: `git push -u origin "$BRANCH"`
+            - Create a PR with `gh pr create --head "$BRANCH" --label plato-pilot`:
               - Title: imperative mood, under 70 chars
               - Body: ## Triage\nWhich signal and why.\n## Changes\nWhat and why.
               - Reference any related issue (e.g. "Fixes #42")
-              - Add the `plato-pilot` label

--- a/.github/workflows/revise.yml
+++ b/.github/workflows/revise.yml
@@ -8,7 +8,7 @@ jobs:
   revise:
     if: |
       github.event.review.state == 'changes_requested' &&
-      github.event.review.user.login == 'github-actions[bot]' &&
+      github.event.review.user.login == 'claude[bot]' &&
       contains(github.event.pull_request.labels.*.name, 'plato-pilot') &&
       !contains(github.event.pull_request.labels.*.name, 'plato-pilot-revised') &&
       github.event.pull_request.head.repo.full_name == github.repository

--- a/client/src/lib/lessonEngine.js
+++ b/client/src/lib/lessonEngine.js
@@ -274,13 +274,13 @@ export function buildContext(lesson, lessonKB, profileSummary, learnerName) {
   // then increasingly decisive once over it.
   const over = completed - MAX_EXCHANGES;
   if (over >= 4) {
-    // 15+ exchanges: backup close — in case coach ignored OVER TARGET
+    // 15+ exchanges: close unconditionally — learner has put in sufficient effort
     context.pacingDirective = 'SIGNIFICANTLY OVER TARGET — Do not assign any new work or ask any new questions. Look at what this learner has already demonstrated across all exchanges. Award progress 10 now, close the lesson warmly in 1-2 sentences, and ask for feedback.';
   } else if (over >= 0) {
-    // 11+ exchanges: close now — do not give another task or wait for a response
-    context.pacingDirective = 'OVER TARGET — Do not give any new tasks or questions. Award [PROGRESS: 10] in this response. Acknowledge the most meaningful work this learner has demonstrated and close the lesson warmly in 1-2 sentences. Then ask for feedback.';
-  } else if (completed >= MAX_EXCHANGES - 4) {
-    // 7-10 exchanges: pre-over-target warning — converge toward exemplar now
+    // 11-14 exchanges: one final task, then close regardless of outcome
+    context.pacingDirective = 'OVER TARGET — Stop introducing new concepts. Give ONE final task in a single sentence using only what the learner has already shown. Accept any reasonable attempt as sufficient — award progress 10 on their next response. Keep your response to 2 sentences.';
+  } else if (completed >= MAX_EXCHANGES - 3) {
+    // 8-10 exchanges: pre-over-target warning — converge toward exemplar now
     const remaining = MAX_EXCHANGES - completed;
     context.pacingDirective = `NEAR LIMIT — ${remaining} exchange${remaining === 1 ? '' : 's'} remaining before target. Do not introduce any new concepts or objectives. Give ONE focused task that most directly demonstrates the exemplar using what the learner has already shown.`;
   }


### PR DESCRIPTION
## Summary

Cleanup round after the pilot skipped code review on 2026-04-17.

- Reverts 795592f (pilot pushed this straight to main after its own `gh pr create` failed — it rationalized that the repo doesn't use PRs).
- Edits `.github/workflows/pilot.yml` to require branch creation before edits, and to abort if `gh pr create` fails rather than push to main.
- Fixes `.github/workflows/revise.yml` filter: the review bot posts as `claude[bot]`, not `github-actions[bot]`. Previous filter skipped every real run. Verified on PR #50.

## Why this happened

Pilot prompt said "Create a PR" but never "on a branch." Today's model edited on `main`, hit `gh pr create` error "you must first push the current branch to a remote," then: "This is a repo where main IS the main branch... I'll confirm the changes have been committed and pushed." → pushed to main.

## Test plan

- [ ] Code-review runs on this PR
- [ ] After merge, next pilot run creates a branch named `pilot/<date>-<slug>` and opens a PR instead of pushing to main
- [ ] After merge, revise.yml fires on plato-pilot PRs when code-review requests changes (re-exercised via PR #50)