### PR TITLE
[TEST] Add pacing classifier helper (exercise revise.yml)

### DIFF
--- a/server/src/lib/lesson-limits.js
+++ b/server/src/lib/lesson-limits.js
@@ -3,3 +3,16 @@
 export const MAX_EXCHANGES = 11;
 export const MIN_OBJECTIVES = 2;
 export const MAX_OBJECTIVES = 4;
+
+// Pacing categories for lesson-length KPI aggregation.
+export const PACING_ON_TARGET = 'on-target';
+export const PACING_NEAR_LIMIT = 'near-limit';
+export const PACING_OVER_TARGET = 'over-target';
+export const PACING_HARD_LIMIT = 'hard-limit';
+
+export function classifyPacing(exchangeCount) {
+  if (exchangeCount >= MAX_EXCHANGES * 2) return PACING_HARD_LIMIT;
+  if (exchangeCount >= MAX_EXCHANGES) return PACING_OVER_TARGET;
+  if (exchangeCount >= MAX_EXCHANGES - 3) return PACING_NEAR_LIMIT;
+  return PACING_ON_TARGET;
+}

--- a/server/tests/lib/lesson-limits.test.js
+++ b/server/tests/lib/lesson-limits.test.js
@@ -1,0 +1,31 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifyPacing,
+  PACING_ON_TARGET,
+  PACING_NEAR_LIMIT,
+  PACING_OVER_TARGET,
+  PACING_HARD_LIMIT,
+} from '../../src/lib/lesson-limits.js';
+
+describe('classifyPacing', () => {
+  it('returns on-target for exchangeCount < 8', () => {
+    assert.equal(classifyPacing(0), PACING_ON_TARGET);
+    assert.equal(classifyPacing(7), PACING_ON_TARGET);
+  });
+
+  it('returns near-limit for exchangeCount 8–10 (boundary at 8)', () => {
+    assert.equal(classifyPacing(8), PACING_NEAR_LIMIT);
+    assert.equal(classifyPacing(10), PACING_NEAR_LIMIT);
+  });
+
+  it('returns over-target for exchangeCount 11–21 (boundary at 11)', () => {
+    assert.equal(classifyPacing(11), PACING_OVER_TARGET);
+    assert.equal(classifyPacing(21), PACING_OVER_TARGET);
+  });
+
+  it('returns hard-limit for exchangeCount >= 22 (boundary at 22)', () => {
+    assert.equal(classifyPacing(22), PACING_HARD_LIMIT);
+    assert.equal(classifyPacing(30), PACING_HARD_LIMIT);
+  });
+});


### PR DESCRIPTION
## Why this PR exists

Purpose-built to exercise `.github/workflows/revise.yml` end-to-end. Adds a small server-lib helper (`classifyPacing`) with **no test coverage**, which should trip the code-review agent's blocking rule for "Missing tests: server route/lib changes without test coverage." If the review bot requests changes, `revise.yml` should fire and push a fixup commit with a test file.

## Expected sequence

1. Code-review runs → requests changes citing missing test
2. Revise fires (plato-pilot label present, not yet plato-pilot-revised)
3. Revise adds a test file, runs `npm test`, pushes fixup commit, comments on PR
4. Label `plato-pilot-revised` gets added → no further revise runs

## If revise works

Squash-merge. The helper is actually useful for future KPI aggregation.

## If revise doesn't fire or misbehaves

Close without merging and iterate on the workflow.