### PR TITLE
Run pilot Sun-Thu only, skip Fri/Sat

### DIFF
--- a/.github/workflows/pilot.yml
+++ b/.github/workflows/pilot.yml
@@ -2,7 +2,7 @@ name: plato-pilot
 
 on:
   schedule:
-    - cron: '11 16 * * *'  # 11:11 AM ET (16:11 UTC) daily
+    - cron: '11 16 * * 0-4'  # 11:11 AM ET (16:11 UTC) Sun–Thu (skips Fri/Sat)
   workflow_dispatch:        # manual trigger for testing
 
 jobs:


### PR DESCRIPTION
## Summary

Changes cron from `'11 16 * * *'` (every day) to `'11 16 * * 0-4'` (Sun–Thu). Fri and Sat are now skipped.

Manual `workflow_dispatch` still works any day.

## Test plan

- [ ] After merge, next Fri/Sat shows no scheduled pilot run in Actions history
- [ ] Sun–Thu runs unchanged