### PR TITLE
Automate deploys via repository_dispatch to private fork

### DIFF
--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -1,0 +1,48 @@
+name: Trigger Deploy
+
+# Fires a repository_dispatch event to the private deploy fork
+# (UIC-OSF/learn.ai-leaders.org), which hosts the actual deploy workflows
+# and AWS credentials. This lets us keep deploy internals out of the public
+# repo without the old "merge-and-push-to-deploy-fork" dance.
+#
+# Requires secret DEPLOY_DISPATCH_TOKEN — a fine-grained PAT with
+# contents:write on UIC-OSF/learn.ai-leaders.org (or a classic PAT with
+# the repo scope).
+
+on:
+  push:
+    branches: [main, playground]
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fire deploy dispatch
+        env:
+          TOKEN: ${{ secrets.DEPLOY_DISPATCH_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "DEPLOY_DISPATCH_TOKEN secret is not set — cannot trigger deploy."
+            echo "Add a fine-grained PAT with contents:write on UIC-OSF/learn.ai-leaders.org"
+            echo "as a repository secret named DEPLOY_DISPATCH_TOKEN."
+            exit 1
+          fi
+          case "$REF_NAME" in
+            main)       EVENT_TYPE="deploy-prod" ;;
+            playground) EVENT_TYPE="deploy-playground" ;;
+            *)          echo "Unexpected branch $REF_NAME — skipping."; exit 0 ;;
+          esac
+          echo "Firing $EVENT_TYPE for $SHA"
+          HTTP_STATUS=$(curl -sS -o /tmp/dispatch-response -w "%{http_code}" \
+            -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/UIC-OSF/learn.ai-leaders.org/dispatches \
+            -d "{\"event_type\":\"$EVENT_TYPE\",\"client_payload\":{\"sha\":\"$SHA\",\"ref\":\"$REF_NAME\"}}")
+          echo "HTTP $HTTP_STATUS"
+          cat /tmp/dispatch-response
+          [ "$HTTP_STATUS" = "204" ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,8 @@ Deploy config: `server/samconfig.toml` (copy from `samconfig.toml.example`, giti
 
 The `template.yaml` accepts a `Stage` parameter (`prod` or `playground`). Each stage gets its own DynamoDB tables and SSM parameters:
 
-- **prod** (`plato` stack) — learn.ai-leaders.org, deploys on push to `main`
-- **playground** (`plato-playground` stack) — playground.ai-leaders.org, deploys on push to `playground`
+- **prod** (`plato` stack) — learn.ai-leaders.org, auto-deploys on push to `main` (via `repository_dispatch` → private fork)
+- **playground** (`plato-playground` stack) — playground.ai-leaders.org, auto-deploys on push to `playground` (via `repository_dispatch` → private fork)
 
 SSM parameters (per stage): `/plato/{stage}/jwt-secret`, `/plato/{stage}/admin-email`, `/plato/{stage}/admin-password`, `/plato/{stage}/ses-from-email`, `/plato/{stage}/app-url`
 
@@ -101,7 +101,7 @@ The site is served via CloudFront -> Lambda Function URL. The Origin Request Pol
 - Always commit and push after changes
 - Run `npm test` before deploying
 - Version in `version.json` (Beta-RC-X format) — auto-bumped by GitHub Action on push to main
-- Deploy workflows live only in the private fork (UIC-OSF/learn.ai-leaders.org), not in the public repo. **Never force-push** to the deploy remote — always merge so the workflow files aren't overwritten. To deploy: `git fetch deploy && git merge deploy/main --no-edit && git push deploy main` (or `playground` for playground)
+- Deploy workflows live only in the private fork (UIC-OSF/learn.ai-leaders.org), not in the public repo. Deploys are automated via `repository_dispatch`: pushing to `main` here triggers `.github/workflows/trigger-deploy.yml`, which fires a `deploy-prod` dispatch to the private fork; pushing to `playground` fires `deploy-playground`. The private fork's `deploy.yml` / `deploy-playground.yml` listen for those events, check this repo out at the dispatched SHA, and run SAM deploy. No more pushing to the deploy remote. One-time setup: a `DEPLOY_DISPATCH_TOKEN` secret on this repo (fine-grained PAT with `contents:write` on the deploy fork). Manual deploy: run the `Deploy to AWS` or `Deploy to Playground` workflow from the private fork's Actions tab via `workflow_dispatch` with an optional `ref` input.
 - API responses for user groups use `{ userGroups: [...] }` consistently
 - Emails use classroom name/colors from settings, with "Powered by plato." footer linking to GitHub
 - Auth pages (login, signup, forgot-password, reset-password) use `usePublicBranding` hook for classroom theming


### PR DESCRIPTION
Replaces the manual \"merge deploy/main → restore workflow files → push deploy main\" dance with an automated dispatch from this public repo to the private deploy fork (\`UIC-OSF/learn.ai-leaders.org\`).

## Why

Deploy internals (AWS roles, SAM config, backup logic) live only in the private fork per CLAUDE.md. Because origin/main has the deploy workflow files removed, merging origin/main into the deploy fork deletes them every time — forcing a restore commit on every deploy.

With this change: pushing to \`main\` or \`playground\` here fires a \`repository_dispatch\` event to the private fork, which then checks out this repo at the dispatched SHA and runs the real deploy. The deploy workflow files never need to touch origin.

## Summary

- Adds \`.github/workflows/trigger-deploy.yml\` that fires on push to main/playground (also supports workflow_dispatch for manual runs).
- Fires \`deploy-prod\` or \`deploy-playground\` dispatch events based on branch, with the commit SHA as payload.
- Fails loudly if the required secret is missing.

## One-time setup required before merging

1. Create a fine-grained personal access token (or classic PAT with \`repo\`) that has \`contents:write\` on \`UIC-OSF/learn.ai-leaders.org\`.
2. Add it to this repo as a secret named \`DEPLOY_DISPATCH_TOKEN\`.
3. Merge the paired PR in \`UIC-OSF/learn.ai-leaders.org\` that switches \`deploy.yml\` and \`deploy-playground.yml\` from push triggers to \`repository_dispatch\`.

## Test plan

- [ ] \`DEPLOY_DISPATCH_TOKEN\` secret added
- [ ] Paired PR in private fork merged
- [ ] Push to main → trigger-deploy job succeeds → deploy-prod dispatch fires → private fork's Deploy to AWS workflow runs and checks out the correct SHA
- [ ] Same flow verified for playground branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)