### PR TITLE
trigger-deploy: add 'target' input for simultaneous deploy

### DIFF
--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -5,6 +5,14 @@ name: Trigger Deploy
 # and AWS credentials. This lets us keep deploy internals out of the public
 # repo without the old "merge-and-push-to-deploy-fork" dance.
 #
+# Automatic triggers:
+#   - push to main       → deploy-prod
+#   - push to playground → deploy-playground
+# Manual triggers (workflow_dispatch):
+#   - target=prod        → deploy-prod (using the current branch's SHA)
+#   - target=playground  → deploy-playground
+#   - target=both        → fires both events simultaneously
+#
 # Requires secret DEPLOY_DISPATCH_TOKEN — a fine-grained PAT with
 # contents:write on UIC-OSF/learn.ai-leaders.org (or a classic PAT with
 # the repo scope).
@@ -13,6 +21,16 @@ on:
   push:
     branches: [main, playground]
   workflow_dispatch:
+    inputs:
+      target:
+        description: 'Which environment(s) to deploy'
+        required: true
+        type: choice
+        options:
+          - prod
+          - playground
+          - both
+        default: prod
 
 jobs:
   dispatch:
@@ -23,26 +41,44 @@ jobs:
           TOKEN: ${{ secrets.DEPLOY_DISPATCH_TOKEN }}
           REF_NAME: ${{ github.ref_name }}
           SHA: ${{ github.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          TARGET: ${{ inputs.target }}
         run: |
           if [ -z "$TOKEN" ]; then
-            echo "DEPLOY_DISPATCH_TOKEN secret is not set — cannot trigger deploy."
+            echo "::error::DEPLOY_DISPATCH_TOKEN secret is not set — cannot trigger deploy."
             echo "Add a fine-grained PAT with contents:write on UIC-OSF/learn.ai-leaders.org"
             echo "as a repository secret named DEPLOY_DISPATCH_TOKEN."
             exit 1
           fi
-          case "$REF_NAME" in
-            main)       EVENT_TYPE="deploy-prod" ;;
-            playground) EVENT_TYPE="deploy-playground" ;;
-            *)          echo "Unexpected branch $REF_NAME — skipping."; exit 0 ;;
-          esac
-          echo "Firing $EVENT_TYPE for $SHA"
-          HTTP_STATUS=$(curl -sS -o /tmp/dispatch-response -w "%{http_code}" \
-            -X POST \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/UIC-OSF/learn.ai-leaders.org/dispatches \
-            -d "{\"event_type\":\"$EVENT_TYPE\",\"client_payload\":{\"sha\":\"$SHA\",\"ref\":\"$REF_NAME\"}}")
-          echo "HTTP $HTTP_STATUS"
-          cat /tmp/dispatch-response
-          [ "$HTTP_STATUS" = "204" ]
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            case "$TARGET" in
+              prod)       EVENTS="deploy-prod" ;;
+              playground) EVENTS="deploy-playground" ;;
+              both)       EVENTS="deploy-prod deploy-playground" ;;
+              *)          echo "::error::Unknown target '$TARGET'"; exit 1 ;;
+            esac
+          else
+            case "$REF_NAME" in
+              main)       EVENTS="deploy-prod" ;;
+              playground) EVENTS="deploy-playground" ;;
+              *)          echo "::warning::Push to unsupported branch '$REF_NAME' — no deploy fired."; exit 0 ;;
+            esac
+          fi
+
+          FAILED=0
+          for EVENT_TYPE in $EVENTS; do
+            echo "Firing $EVENT_TYPE for $SHA"
+            HTTP_STATUS=$(curl -sS -o /tmp/dispatch-response -w "%{http_code}" \
+              -X POST \
+              -H "Authorization: Bearer $TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/UIC-OSF/learn.ai-leaders.org/dispatches \
+              -d "{\"event_type\":\"$EVENT_TYPE\",\"client_payload\":{\"sha\":\"$SHA\",\"ref\":\"$REF_NAME\"}}")
+            echo "  HTTP $HTTP_STATUS"
+            cat /tmp/dispatch-response
+            echo
+            [ "$HTTP_STATUS" = "204" ] || FAILED=1
+          done
+          exit $FAILED

--- a/.github/workflows/trigger-deploy.yml
+++ b/.github/workflows/trigger-deploy.yml
@@ -58,6 +58,16 @@ jobs:
               both)       EVENTS="deploy-prod deploy-playground" ;;
               *)          echo "::error::Unknown target '$TARGET'"; exit 1 ;;
             esac
+            # Warn if deploying prod from a branch that's not main — the
+            # dispatched SHA is this branch's HEAD, which may not be what
+            # you want.
+            case "$TARGET" in
+              prod|both)
+                if [ "$REF_NAME" != "main" ]; then
+                  echo "::warning::Deploying to prod from '$REF_NAME' (not main). SHA $SHA will go live."
+                fi
+                ;;
+            esac
           else
             case "$REF_NAME" in
               main)       EVENTS="deploy-prod" ;;


### PR DESCRIPTION
Follow-up to #54. Keeps per-branch auto-triggers (main → prod, playground → playground) but adds a \`workflow_dispatch\` input for manual runs: **prod**, **playground**, or **both**. Useful when you want both environments updated simultaneously from the same SHA without two separate pushes.

Also switches the unmatched-branch exit (from push events on other branches) to a \`::warning::\` annotation so manual runs on feature branches don't silently vanish — addresses a non-blocking note from the #54 review.

## Test plan

- [ ] Run the workflow via Actions tab with target=playground → fires one dispatch
- [ ] Run with target=both → fires two dispatches (prod + playground)
- [ ] Existing push-to-main and push-to-playground behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)