### PR TITLE
Move version bump to PR branch; tag post-merge

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,43 +1,60 @@
 name: Bump version
 
+# Version bump happens on the PR branch during review so it shows up in
+# the PR diff and never needs to push to protected main.
+#
+# On push to main (after merge), a sibling workflow creates the git tag
+# and GitHub release — tags aren't covered by the branch ruleset.
+
 on:
   pull_request:
-    types: [closed]
+    types: [opened, synchronize, reopened]
     branches: [main]
 
 jobs:
   bump:
-    if: github.event.pull_request.merged == true
+    # Skip if the PR branch is on a fork (we can't push back to forks)
+    # and skip if this PR is from the bump workflow itself (to avoid loops).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
 
-      - name: Bump RC number
+      - name: Compute next version and bump if needed
         id: version
         run: |
-          current=$(python3 -c "import json; print(json.load(open('version.json'))['version'])")
-          rc_num=$(echo "$current" | grep -oP '\d+$')
-          new_num=$((rc_num + 1))
-          new_version="Beta-RC-${new_num}"
-          echo "{\"version\": \"${new_version}\"}" > version.json
-          echo "version=${new_version}" >> "$GITHUB_OUTPUT"
-          echo "Bumped $current -> $new_version"
+          # What version does main currently have?
+          main_version=$(git show origin/${{ github.event.pull_request.base.ref }}:version.json | python3 -c "import json, sys; print(json.load(sys.stdin)['version'])")
+          pr_version=$(python3 -c "import json; print(json.load(open('version.json'))['version'])")
 
-      - name: Commit and tag
+          rc_num=$(echo "$main_version" | grep -oP '\d+$')
+          next_num=$((rc_num + 1))
+          next_version="Beta-RC-${next_num}"
+
+          echo "main=$main_version pr=$pr_version next=$next_version"
+
+          if [ "$pr_version" = "$next_version" ]; then
+            echo "PR branch already at $next_version — nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "{\"version\": \"${next_version}\"}" > version.json
+          echo "version=${next_version}" >> "$GITHUB_OUTPUT"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit bump to PR branch
+        if: steps.version.outputs.changed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add version.json
           git commit -m "Bump version to ${{ steps.version.outputs.version }}"
-          git tag "${{ steps.version.outputs.version }}"
-          git push && git push --tags
-
-      - name: Create release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release create "${{ steps.version.outputs.version }}" \
-            --title "${{ steps.version.outputs.version }}" \
-            --generate-notes
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -1,0 +1,56 @@
+name: Tag version and create release
+
+# Companion to version-bump.yml. The bump happens on the PR branch; once
+# the PR merges to main, this workflow tags the merge commit with the
+# version and creates a GitHub release. Tags are not covered by the
+# branch protection ruleset, so no bypass is needed.
+
+on:
+  push:
+    branches: [main]
+    paths: [version.json]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read current version
+        id: version
+        run: |
+          current=$(python3 -c "import json; print(json.load(open('version.json'))['version'])")
+          echo "version=$current" >> "$GITHUB_OUTPUT"
+          echo "Current version: $current"
+
+      - name: Skip if tag already exists
+        id: check
+        run: |
+          if git rev-parse "refs/tags/${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "Tag ${{ steps.version.outputs.version }} already exists — skipping."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.version }}"
+
+      - name: Create GitHub release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.version.outputs.version }}" \
+            --title "${{ steps.version.outputs.version }}" \
+            --generate-notes

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{"version": "Beta-RC-38"}
+{"version": "Beta-RC-39"}


### PR DESCRIPTION
Addresses the branch-protection-vs-version-bump problem without bypass.

## Why

Main and playground are now covered by a ruleset that requires PRs through review. The old \`version-bump.yml\` pushed a bump commit directly to main post-merge using GITHUB_TOKEN — which the ruleset blocks. Integration bypass can't be added for user-owned repos (GitHub rejects it), so we move the bump to somewhere not protected.

## How

Split into two workflows:

**\`version-bump.yml\`** (rewritten):
- Trigger: \`pull_request: [opened, synchronize, reopened]\`, targeting \`main\`
- Computes next version from main's current \`version.json\` + 1
- If PR branch's \`version.json\` already matches next, no-op (prevents loops and handles re-runs)
- Otherwise commits the bump to the PR branch — shows up in the PR diff
- Skips PRs from forks (can't push back) and PRs authored by \`github-actions[bot]\`

**\`version-tag.yml\`** (new):
- Trigger: \`push: main\`, \`paths: [version.json]\`
- Reads the new version from \`version.json\` on main
- Skips if tag already exists (idempotent)
- Creates the git tag and a GitHub release with auto-generated notes
- Tags aren't covered by the branch ruleset, so this runs without bypass

## Multi-PR behavior

If two PRs are open, both see main at e.g. \`Beta-RC-38\` and bump their own branches to \`Beta-RC-39\`. When the first merges, main is now at \`Beta-RC-39\`. The second PR's next synchronize event sees main at \`Beta-RC-39\` and re-bumps its branch to \`Beta-RC-40\` automatically.

## Test plan

- [ ] This PR itself should get a bump commit pushed by the workflow shortly after open
- [ ] Version bump appears in the PR's file diff
- [ ] On merge: \`version-tag.yml\` runs and creates tag \`Beta-RC-{N+1}\` + release
- [ ] Ruleset still enforced — confirm merging requires review + passing \`review\` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)