### PR TITLE
Switch versioning to tag-only (no more file commits to main)

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,43 +1,54 @@
-name: Bump version
+name: Tag version
+
+# On push to main (post-merge), create the next Beta-RC-N git tag and a
+# GitHub release. Tags are not covered by the branch protection ruleset,
+# so this runs with the default GITHUB_TOKEN and no bypass is needed.
+#
+# version.json lives only in builds — it's generated at deploy time from
+# the latest tag (see the private deploy fork's deploy.yml). No file is
+# tracked in git, no commits land on main from this workflow.
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
-  bump:
-    if: github.event.pull_request.merged == true
+  tag:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Bump RC number
+      - name: Determine next version
         id: version
         run: |
-          current=$(python3 -c "import json; print(json.load(open('version.json'))['version'])")
-          rc_num=$(echo "$current" | grep -oP '\d+$')
-          new_num=$((rc_num + 1))
-          new_version="Beta-RC-${new_num}"
-          echo "{\"version\": \"${new_version}\"}" > version.json
-          echo "version=${new_version}" >> "$GITHUB_OUTPUT"
-          echo "Bumped $current -> $new_version"
+          # Find highest existing Beta-RC-N tag (sort numerically on the trailing number).
+          latest_num=$(git tag -l "Beta-RC-*" \
+            | sed 's/^Beta-RC-//' \
+            | grep -E '^[0-9]+$' \
+            | sort -n \
+            | tail -1)
+          next_num=$(( ${latest_num:-0} + 1 ))
+          next="Beta-RC-${next_num}"
+          echo "Latest: ${latest_num:-<none>} → Next: $next"
+          echo "next=$next" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and tag
+      - name: Create and push tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add version.json
-          git commit -m "Bump version to ${{ steps.version.outputs.version }}"
-          git tag "${{ steps.version.outputs.version }}"
-          git push && git push --tags
+          git tag "${{ steps.version.outputs.next }}"
+          git push origin "${{ steps.version.outputs.next }}"
 
-      - name: Create release
+      - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ steps.version.outputs.version }}" \
-            --title "${{ steps.version.outputs.version }}" \
+          gh release create "${{ steps.version.outputs.next }}" \
+            --title "${{ steps.version.outputs.next }}" \
             --generate-notes

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -24,8 +24,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Skip if commit already tagged
+        id: existing
+        run: |
+          # Idempotent: if this commit already carries a Beta-RC-* tag
+          # (e.g. workflow_dispatch re-run after the initial push-trigger
+          # already tagged it), don't create a second tag.
+          existing=$(git tag --points-at HEAD | grep -E '^Beta-RC-[0-9]+$' | head -1 || true)
+          if [ -n "$existing" ]; then
+            echo "Commit already tagged as $existing — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Determine next version
         id: version
+        if: steps.existing.outputs.skip == 'false'
         run: |
           # Find highest existing Beta-RC-N tag (sort numerically on the trailing number).
           latest_num=$(git tag -l "Beta-RC-*" \
@@ -39,6 +54,7 @@ jobs:
           echo "next=$next" >> "$GITHUB_OUTPUT"
 
       - name: Create and push tag
+        if: steps.existing.outputs.skip == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -46,6 +62,7 @@ jobs:
           git push origin "${{ steps.version.outputs.next }}"
 
       - name: Create GitHub release
+        if: steps.existing.outputs.skip == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ server/client-content/
 .github/workflows/deploy.yml
 .github/workflows/deploy-playground.yml
 .DS_Store
+
+# Generated at deploy time from the latest Beta-RC-* tag.
+# See .github/workflows/version-bump.yml (tag creation) and the private
+# deploy fork's deploy.yml (version.json generation).
+version.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,9 @@ cp -r ../client/dist .aws-sam/build/PlatoApiFunction/client-dist
 mkdir -p .aws-sam/build/PlatoApiFunction/client-content .aws-sam/build/PlatoStreamFunction/client-content
 cp -r ../client/prompts ../client/data .aws-sam/build/PlatoApiFunction/client-content/
 cp -r ../client/prompts ../client/data .aws-sam/build/PlatoStreamFunction/client-content/
-cp ../version.json .aws-sam/build/PlatoApiFunction/
-cp ../version.json .aws-sam/build/PlatoStreamFunction/
+# version.json is generated at deploy time from the latest Beta-RC-* tag
+echo "{\"version\":\"$(git describe --tags --abbrev=0 --match='Beta-RC-*')\"}" > .aws-sam/build/PlatoApiFunction/version.json
+cp .aws-sam/build/PlatoApiFunction/version.json .aws-sam/build/PlatoStreamFunction/version.json
 sam deploy
 ```
 
@@ -100,7 +101,7 @@ The site is served via CloudFront -> Lambda Function URL. The Origin Request Pol
 - Chat accessibility: the chat log uses `role="log"` with `aria-live="off"` and `aria-label="Chat log"` to prevent VoiceOver hijacking. New message announcements go through a separate `role="status"` live region that auto-clears ~3s after each announcement so stale text doesn't persist as navigable content. Streaming `AssistantMessage` components must set `streaming` prop to hide from screen readers. Individual messages are plain `<div>`s (no `role="article"`, no per-message `aria-label`) with inline sr-only speaker prefixes ("Coach says:" / "You said:") that flow as content, plus `data-chat-message` attributes for Alt+Arrow keyboard navigation (`useChatKeyboardNav` hook). The Objectives dialog moves focus to its title on open so screen readers announce the dialog's purpose. `useTitleNotification` hook flashes document title for background tab notifications. `ComposeBar` sends on Cmd/Ctrl+Enter; plain Enter inserts a newline.
 - Always commit and push after changes
 - Run `npm test` before deploying
-- Version in `version.json` (Beta-RC-X format) — auto-bumped by GitHub Action on push to main
+- Version is tag-based (`Beta-RC-X`). On push to main, `.github/workflows/version-bump.yml` creates the next `Beta-RC-N` git tag + GitHub release. There's no `version.json` tracked in git — the deploy workflow generates it from the latest tag before packaging Lambda. Local dev: no version.json means the admin sidebar hides the version label; that's intentional.
 - Deploy workflows live only in the private fork (UIC-OSF/learn.ai-leaders.org), not in the public repo. Deploys are automated via `repository_dispatch`: pushing to `main` here triggers `.github/workflows/trigger-deploy.yml`, which fires a `deploy-prod` dispatch to the private fork; pushing to `playground` fires `deploy-playground`. The private fork's `deploy.yml` / `deploy-playground.yml` listen for those events, check this repo out at the dispatched SHA, and run SAM deploy. No more pushing to the deploy remote. One-time setup: a `DEPLOY_DISPATCH_TOKEN` secret on this repo (fine-grained PAT with `contents:write` on the deploy fork). Manual deploy: run the `Deploy to AWS` or `Deploy to Playground` workflow from the private fork's Actions tab via `workflow_dispatch` with an optional `ref` input.
 - API responses for user groups use `{ userGroups: [...] }` consistently
 - Emails use classroom name/colors from settings, with "Powered by plato." footer linking to GitHub
@@ -133,4 +134,3 @@ The site is served via CloudFront -> Lambda Function URL. The Origin Request Pol
 - `client/src/hooks/useTitleNotification.js` — document title flash for new-message notifications
 - `client/src/lib/constants.js` — microlearning limits (MAX_EXCHANGES, MIN/MAX_OBJECTIVES) and shared constants
 - `server/src/lib/lesson-limits.js` — server-side mirror of microlearning limits
-- `version.json` — current version (Beta-RC-X), auto-bumped on PR merge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,8 @@ mkdir -p .aws-sam/build/PlatoApiFunction/client-content .aws-sam/build/PlatoStre
 cp -r ../client/prompts ../client/data .aws-sam/build/PlatoApiFunction/client-content/
 cp -r ../client/prompts ../client/data .aws-sam/build/PlatoStreamFunction/client-content/
 # version.json is generated at deploy time from the latest Beta-RC-* tag
-echo "{\"version\":\"$(git describe --tags --abbrev=0 --match='Beta-RC-*')\"}" > .aws-sam/build/PlatoApiFunction/version.json
+VERSION=$(git describe --tags --abbrev=0 --match='Beta-RC-*' 2>/dev/null || echo 'Beta-RC-0')
+echo "{\"version\":\"${VERSION}\"}" > .aws-sam/build/PlatoApiFunction/version.json
 cp .aws-sam/build/PlatoApiFunction/version.json .aws-sam/build/PlatoStreamFunction/version.json
 sam deploy
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ The `main` branch is protected — direct pushes are not allowed. All changes go
 3. Run tests — they must pass.
 4. Open a pull request with a clear summary of what changed and why.
 
-When a PR is merged, the version in `version.json` is automatically bumped.
+When a PR is merged to `main`, a new `Beta-RC-N` git tag and GitHub release are created automatically. Version is tag-based — `version.json` is not tracked in git and is generated at deploy time.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -207,8 +207,11 @@ cp -r ../client/dist .aws-sam/build/PlatoApiFunction/client-dist
 mkdir -p .aws-sam/build/PlatoApiFunction/client-content .aws-sam/build/PlatoStreamFunction/client-content
 cp -r ../client/prompts ../client/data .aws-sam/build/PlatoApiFunction/client-content/
 cp -r ../client/prompts ../client/data .aws-sam/build/PlatoStreamFunction/client-content/
-cp ../version.json .aws-sam/build/PlatoApiFunction/
-cp ../version.json .aws-sam/build/PlatoStreamFunction/
+
+# Generate version.json from the latest Beta-RC-* tag
+VERSION=$(git describe --tags --abbrev=0 --match='Beta-RC-*' 2>/dev/null || echo 'Beta-RC-0')
+echo "{\"version\":\"${VERSION}\"}" > .aws-sam/build/PlatoApiFunction/version.json
+cp .aws-sam/build/PlatoApiFunction/version.json .aws-sam/build/PlatoStreamFunction/version.json
 
 # Deploy (default stage is prod)
 sam deploy
@@ -306,6 +309,7 @@ jobs:
         with:
           repository: ${{ env.SOURCE_REPO }}
           ref: ${{ env.SOURCE_REF }}
+          fetch-depth: 0  # need history + tags so we can read the latest Beta-RC-* tag
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -325,9 +329,11 @@ jobs:
           mkdir -p server/.aws-sam/build/PlatoApiFunction/client-content server/.aws-sam/build/PlatoStreamFunction/client-content
           cp -r client/prompts client/data server/.aws-sam/build/PlatoApiFunction/client-content/
           cp -r client/prompts client/data server/.aws-sam/build/PlatoStreamFunction/client-content/
-      - run: |
-          cp version.json server/.aws-sam/build/PlatoApiFunction/
-          cp version.json server/.aws-sam/build/PlatoStreamFunction/
+      - name: Generate version.json from latest tag
+        run: |
+          VERSION=$(git describe --tags --abbrev=0 --match='Beta-RC-*' 2>/dev/null || echo 'Beta-RC-0')
+          echo "{\"version\":\"${VERSION}\"}" > server/.aws-sam/build/PlatoApiFunction/version.json
+          cp server/.aws-sam/build/PlatoApiFunction/version.json server/.aws-sam/build/PlatoStreamFunction/version.json
       - run: >
           cd server && sam deploy
           --config-env ci
@@ -387,7 +393,7 @@ In both cases, DynamoDB restores to a new table — rename or swap as needed.
 
 ## Versioning
 
-plato uses a `Beta-RC-X` version scheme stored in `version.json`. The version is bumped automatically when a PR is merged to main via the `version-bump.yml` GitHub Action. The current version is displayed in the admin sidebar with a link to the GitHub repo.
+plato uses a `Beta-RC-X` version scheme tracked via git tags. On each push to `main` (typically from a merged PR), `.github/workflows/version-bump.yml` creates the next `Beta-RC-N` tag and a matching GitHub release. No version file is tracked in git — `version.json` is generated at deploy time from the latest tag and included in the Lambda bundle. The current version is displayed in the admin sidebar with a link to the GitHub repo.
 
 The `main` branch is protected — all changes require a pull request.
 

--- a/version.json
+++ b/version.json
@@ -1,1 +1,0 @@
-{"version": "Beta-RC-38"}


### PR DESCRIPTION
Replaces PR #58. Addresses the "each PR review costs money" problem by avoiding any extra review triggers on version bump.

## Why

- Branch protection blocks GITHUB_TOKEN from pushing to main directly.
- Integration bypass isn't available for user-owned repos (GitHub API rejects app_id 15368).
- The PR-branch-bump approach worked but doubled adversarial-review cost by re-triggering the review workflow on each bump commit.

## Approach

Version is now tracked solely via git tags (\`Beta-RC-N\`). No \`version.json\` lives in the repo.

- **\`.github/workflows/version-bump.yml\`** (renamed conceptually to "Tag version") fires on push to main, reads the highest existing \`Beta-RC-*\` tag, creates the next one, and opens a GitHub release. Tags are outside the branch ruleset so the default GITHUB_TOKEN can push them. Idempotent (re-runs skip if the tag already exists).
- **\`version.json\`** removed from git, added to \`.gitignore\`. Locally the server's \`/v1/version\` returns \`{version: null}\` when the file is missing and the client already hides the sidebar version label in that case — no code changes needed.
- The deploy workflows (in the private fork UIC-OSF/learn.ai-leaders.org) need to generate \`version.json\` from the latest tag before SAM build. **Paired PR on the deploy fork handles that** — merge both together.

## Review cost

Each PR now triggers exactly one review run on the developer's commits. The tag workflow on main doesn't trigger the review workflow (it fires on push events, not PRs).

## Test plan

- [ ] Merge this PR and the paired fork PR
- [ ] Confirm this PR's merge fires \`version-bump.yml\` → creates tag \`Beta-RC-N\` + release
- [ ] Confirm the subsequent dispatched deploy includes \`version.json\` with the new tag in the Lambda bundle
- [ ] Admin sidebar on learn.ai-leaders.org shows the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)