### PR TITLE
Add /v1/admin/logs endpoint with in-app logger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ plato is an open-source, AI-powered [microlearning](https://philosophers.group/p
 - Pacing: lessons target 11 exchanges (~20 min). No hard cutoff — coach gets escalating `pacingDirective` in context JSON at 11+, 15+, 20+ exchanges. Hard limit at 2x target (22) as safety net.
 - Classroom branding (colors, logo, name) stored in `_system` settings, fetched via `/v1/branding` (public, no auth)
 - Admin dashboard at `/plato` (lazy-loaded, role-gated) with Lesson Pacing KPIs (on-target rate, over-target count, hard-limit hits)
+- Server logging: `server/src/lib/logger.js` — ring-buffer logger keyed by snake_case `code` strings (not free-form messages). Emits structured JSON to stdout so Lambda → CloudWatch captures the same shape. `GET /v1/admin/logs` merges the in-process buffer with CloudWatch (the Lambda has `logs:FilterLogEvents` scoped to `/aws/lambda/plato-${Stage}-*`). The pilot agent is the primary consumer — response is pre-aggregated into `groups` by code with counts, firstSeen/lastSeen, and a sample entry. CloudWatch failures populate `cloudwatch.error` instead of silently returning empty.
 
 ## Development
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ plato is an open-source, AI-powered [microlearning](https://philosophers.group/p
 - Pacing: lessons target 11 exchanges (~20 min). No hard cutoff — coach gets escalating `pacingDirective` in context JSON at 11+, 15+, 20+ exchanges. Hard limit at 2x target (22) as safety net.
 - Classroom branding (colors, logo, name) stored in `_system` settings, fetched via `/v1/branding` (public, no auth)
 - Admin dashboard at `/plato` (lazy-loaded, role-gated) with Lesson Pacing KPIs (on-target rate, over-target count, hard-limit hits)
-- Server logging: `server/src/lib/logger.js` — ring-buffer logger keyed by snake_case `code` strings (not free-form messages). Emits structured JSON to stdout so Lambda → CloudWatch captures the same shape. `GET /v1/admin/logs` merges the in-process buffer with CloudWatch (the Lambda has `logs:FilterLogEvents` scoped to `/aws/lambda/plato-${Stage}-*`). The pilot agent is the primary consumer — response is pre-aggregated into `groups` by code with counts, firstSeen/lastSeen, and a sample entry. CloudWatch failures populate `cloudwatch.error` instead of silently returning empty.
+- Server logging: `server/src/lib/logger.js` — ring-buffer logger keyed by snake_case `code` strings (not free-form messages). Each call mirrors a structured JSON line to stdout that includes `logId`, so Lambda → CloudWatch captures the same shape and the endpoint can dedupe events retrieved from both lanes. `GET /v1/admin/logs` merges the in-process buffer with CloudWatch (Lambda has `logs:FilterLogEvents` scoped to `/aws/lambda/plato-${Stage}-*`). CloudWatch is queried with two required-term patterns (`ERROR` and `"Task timed out"`) — never the all-optional `?FOO ?BAR` form, which CloudWatch treats as match-everything. The pilot agent is the primary consumer: response is pre-aggregated into `groups` by code with counts, firstSeen/lastSeen, and a sample entry. CloudWatch failures populate `cloudwatch.error` instead of silently returning empty.
 
 ## Development
 
@@ -54,7 +54,7 @@ Client hot reload: `cd client && npm run dev` (port 5173, proxies API to :3000)
 cd server && npm test
 ```
 
-104 tests. AI route tests mock `ai-provider.js` (not `bedrock.js`).
+122 tests. AI route tests mock `ai-provider.js` (not `bedrock.js`).
 
 ## Deploy to AWS
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.700.0",
+        "@aws-sdk/client-cloudwatch-logs": "^3.700.0",
         "@aws-sdk/client-dynamodb": "^3.700.0",
         "@aws-sdk/client-ses": "^3.700.0",
         "@aws-sdk/lib-dynamodb": "^3.700.0",
@@ -219,6 +220,59 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-cloudwatch-logs": {
+      "version": "3.1031.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.1031.0.tgz",
+      "integrity": "sha512-xfEzfhy+IhASKOm4QqjjsCECVoZWT6B6ei6WRvIf/l13w+UB719SAsWuT+h+Zh7wktnxIWcHLZN2d7HalWlrWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/credential-provider-node": "^3.972.31",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.30",
+        "@aws-sdk/region-config-resolver": "^3.972.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.16",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/core": "^3.23.15",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-retry": "^4.5.3",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.47",
+        "@smithy/util-defaults-mode-node": "^4.2.52",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.1012.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1012.0.tgz",
@@ -324,22 +378,22 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.24.tgz",
-      "integrity": "sha512-vvf82RYQu2GidWAuQq+uIzaPz9V0gSCXVqdVzRosgl5rXcspXOpSD3wFreGGW6AYymPr97Z69kjVnLePBxloDw==",
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.0.tgz",
+      "integrity": "sha512-8j+dMtyDqNXFmi09CBdz8TY6Ltf2jhfHuP6ZvG4zVjndRc6JF0aeBUbRwQLndbptFCsdctRQgdNWecy4TIfXAw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/xml-builder": "^3.972.15",
-        "@smithy/core": "^3.23.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.18",
+        "@smithy/core": "^3.23.15",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.14",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -348,15 +402,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.22.tgz",
-      "integrity": "sha512-cXp0VTDWT76p3hyK5D51yIKEfpf6/zsUvMfaB8CkyqadJxMQ8SbEeVroregmDlZbtG31wkj9ei0WnftmieggLg==",
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.26.tgz",
+      "integrity": "sha512-WBHAMxyPdgeJY6ZGLvq9mJwzZ+GaNUROQbfdVshtMsDVBrZTj5ZuFjKclSjSHvKSHJ4Y4O2yvI/aA/hrJbYfng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -364,20 +418,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.24.tgz",
-      "integrity": "sha512-h694K7+tRuepSRJr09wTvQfaEnjzsKZ5s7fbESrVds02GT/QzViJ94/HCNwM7bUfFxqpPXHxulZfL6Cou0dwPg==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.28.tgz",
+      "integrity": "sha512-+1DwCjjpo1WoiZTN08yGitI3nUwZUSQWVWFrW4C46HqZwACjcUQ7C66tnKPBTVxrEYYDOP11A6Afmu1L6ylt3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.0",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.7",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.20",
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.23",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -385,24 +439,24 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.24.tgz",
-      "integrity": "sha512-O46fFmv0RDFWiWEA9/e6oW92BnsyAXuEgTTasxHligjn2RCr9L/DK773m/NoFaL3ZdNAUz8WxgxunleMnHAkeQ==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.30.tgz",
+      "integrity": "sha512-Fg1oJcoijwOZjTxdbx+ubqbQl8YEQ4Cwhjw6TWzQjuDEvQYNhnCXW2pN7eKtdTrdE4a6+5TVKGSm2I+i2BKIQg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/credential-provider-env": "^3.972.22",
-        "@aws-sdk/credential-provider-http": "^3.972.24",
-        "@aws-sdk/credential-provider-login": "^3.972.24",
-        "@aws-sdk/credential-provider-process": "^3.972.22",
-        "@aws-sdk/credential-provider-sso": "^3.972.24",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.24",
-        "@aws-sdk/nested-clients": "^3.996.14",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/credential-provider-env": "^3.972.26",
+        "@aws-sdk/credential-provider-http": "^3.972.28",
+        "@aws-sdk/credential-provider-login": "^3.972.30",
+        "@aws-sdk/credential-provider-process": "^3.972.26",
+        "@aws-sdk/credential-provider-sso": "^3.972.30",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.30",
+        "@aws-sdk/nested-clients": "^3.996.20",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -410,18 +464,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.24.tgz",
-      "integrity": "sha512-sIk8oa6AzDoUhxsR11svZESqvzGuXesw62Rl2oW6wguZx8i9cdGCvkFg+h5K7iucUZP8wyWibUbJMc+J66cu5g==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.30.tgz",
+      "integrity": "sha512-nchIrrI/7dgjG1bW/DEWOJc00K9n+kkl6B8Mk0KO6d4GfWBOXlVr9uHp7CJR9FIrjmov5SGjHXG2q9XAtkRw6Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/nested-clients": "^3.996.14",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/nested-clients": "^3.996.20",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -429,22 +483,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.25.tgz",
-      "integrity": "sha512-m7dR0Dsva2P+VUpL+VkC0WwiDby5pgmWXkRVDB5rlwv0jXJrQJf7YMtCoM8Wjk0H9jPeCYOxOXXcIgp/qp5Alg==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.31.tgz",
+      "integrity": "sha512-99OHVQ6eZ5DTxiOWgHdjBMvLqv7xoY4jLK6nZ1NcNSQbAnYZkQNIHi/VqInc9fnmg7of9si/z+waE6YL9OQIlw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.22",
-        "@aws-sdk/credential-provider-http": "^3.972.24",
-        "@aws-sdk/credential-provider-ini": "^3.972.24",
-        "@aws-sdk/credential-provider-process": "^3.972.22",
-        "@aws-sdk/credential-provider-sso": "^3.972.24",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.24",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/credential-provider-env": "^3.972.26",
+        "@aws-sdk/credential-provider-http": "^3.972.28",
+        "@aws-sdk/credential-provider-ini": "^3.972.30",
+        "@aws-sdk/credential-provider-process": "^3.972.26",
+        "@aws-sdk/credential-provider-sso": "^3.972.30",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.30",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -452,16 +506,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.22.tgz",
-      "integrity": "sha512-Os32s8/4gTZjBk5BtoS/cuTILaj+K72d0dVG7TCJX/fC4598cxwLDmf1AEHEpER5oL3K//yETjvFaz0V8oO5Xw==",
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.26.tgz",
+      "integrity": "sha512-jibxNld3m+vbmQwn98hcQ+fLIVrx3cQuhZlSs1/hix48SjDS5/pjMLwpmtLD/lFnd6ve1AL4o1bZg3X1WRa2SQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -469,18 +523,36 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.24.tgz",
-      "integrity": "sha512-PaFv7snEfypU2yXkpvfyWgddEbDLtgVe51wdZlinhc2doubBjUzJZZpgwuF2Jenl1FBydMhNpMjD6SBUM3qdSA==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.30.tgz",
+      "integrity": "sha512-honYIM17F/+QSWJRE84T4u//ofqEi7rLbnwmIpu7fgFX5PML78wbtdSAy5Xwyve3TLpE9/f9zQx0aBVxSjAOPw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/nested-clients": "^3.996.14",
-        "@aws-sdk/token-providers": "3.1015.0",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/nested-clients": "^3.996.20",
+        "@aws-sdk/token-providers": "3.1031.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1031.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1031.0.tgz",
+      "integrity": "sha512-zj/PvnbQK/2KJNln5K2QRI9HSsy+B4emz2gbQyUHkk6l7Lidu83P/9tfmC2cJXkcC3vdmyKH2DP3Iw/FDfKQuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/nested-clients": "^3.996.20",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -488,17 +560,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.24.tgz",
-      "integrity": "sha512-J6H4R1nvr3uBTqD/EeIPAskrBtET4WFfNhpFySr2xW7bVZOXpQfPjrLSIx65jcNjBmLXzWq8QFLdVoGxiGG/SA==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.30.tgz",
+      "integrity": "sha512-CyL4oWUlONQRN2SsYMVrA9Z3i3QfLWTQctI8tuKbjNGCVVDCnJf/yMbSJCOZgpPFRtxh7dgQwvpqwmJm+iytmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/nested-clients": "^3.996.14",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/nested-clients": "^3.996.20",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -603,14 +675,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
-      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -618,13 +690,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
-      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -632,15 +704,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.8.tgz",
-      "integrity": "sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/types": "^3.973.8",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -648,18 +720,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.25.tgz",
-      "integrity": "sha512-QxiMPofvOt8SwSynTOmuZfvvPM1S9QfkESBxB22NMHTRXCJhR5BygLl8IXfC4jELiisQgwsgUby21GtXfX3f/g==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.30.tgz",
+      "integrity": "sha512-lCz6JfelhjD6Eco1urXM2rOYRaxROSqeoY6IEKx+soegFJOajmIBCMHTAWuJl25Wf9IAST+i0/yOk9G3rMV26A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@smithy/core": "^3.23.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-retry": "^4.2.12",
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@smithy/core": "^3.23.15",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -690,47 +762,47 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.14.tgz",
-      "integrity": "sha512-fSESKvh1VbfjtV3QMnRkCPZWkUbQof6T/DOpiLp33yP2wA+rbwwnZeG3XT3Ekljgw2I8X4XaQPnw+zSR8yxJ5Q==",
+      "version": "3.996.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.20.tgz",
+      "integrity": "sha512-bzPdsNQnCh6TvvUmTHLZlL8qgyME6mNiUErcRMyJPywIl1BEu2VZRShel3mUoSh89bOBEXEWtjocDMolFxd/9A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.24",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
-        "@aws-sdk/middleware-user-agent": "^3.972.25",
-        "@aws-sdk/region-config-resolver": "^3.972.9",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.11",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.12",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.27",
-        "@smithy/middleware-retry": "^4.4.44",
-        "@smithy/middleware-serde": "^4.2.15",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.0",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.7",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.30",
+        "@aws-sdk/region-config-resolver": "^3.972.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.16",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/core": "^3.23.15",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-retry": "^4.5.3",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.43",
-        "@smithy/util-defaults-mode-node": "^4.2.47",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-defaults-mode-browser": "^4.3.47",
+        "@smithy/util-defaults-mode-node": "^4.2.52",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -739,15 +811,15 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.9.tgz",
-      "integrity": "sha512-eQ+dFU05ZRC/lC2XpYlYSPlXtX3VT8sn5toxN2Fv7EXlMoA2p9V7vUBKqHunfD4TRLpxUq8Y8Ol/nCqiv327Ng==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.12.tgz",
+      "integrity": "sha512-QQI43Mxd53nBij0pm8HXC+t4IOC6gnhhZfzxE0OATQyO6QfPV4e+aTIRRuAJKA6Nig/cR8eLwPryqYTX9ZrjAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -773,12 +845,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
-      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -801,15 +873,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "version": "3.996.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.7.tgz",
+      "integrity": "sha512-ty4LQxN1QC+YhUP28NfEgZDEGXkyqOQy+BDriBozqHsrYO4JMgiPhfizqOGF7P+euBTZ5Ez6SKlLAMCLo8tzmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-endpoints": "^3.3.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -844,27 +916,27 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
-      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.11.tgz",
-      "integrity": "sha512-1qdXbXo2s5MMLpUvw00284LsbhtlQ4ul7Zzdn5n+7p4WVgCMLqhxImpHIrjSoc72E/fyc4Wq8dLtUld2Gsh+lA==",
+      "version": "3.973.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.16.tgz",
+      "integrity": "sha512-ccvu0FNCI0C6OqmxI/tWn7BD8qGooWuURssiIM+6vbksFO8opXR4JOGtGYPj8QYzN/vfwNYrcK344PPbYuvzRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.25",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/middleware-user-agent": "^3.972.30",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -881,12 +953,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.15.tgz",
-      "integrity": "sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
+      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "fast-xml-parser": "5.5.8",
         "tslib": "^2.6.2"
       },
@@ -977,16 +1049,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
-      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.16.tgz",
+      "integrity": "sha512-GFlGPNLZKrGfqWpqVb31z7hvYCA9ZscfX1buYnvvMGcRYsQQnhH+4uN6mWWflcD5jB4OXP/LBrdpukEdjl41tg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -994,18 +1066,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.12",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
-      "integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
+      "version": "3.23.15",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.15.tgz",
+      "integrity": "sha512-E7GVCgsQttzfujEZb6Qep005wWf4xiL4x06apFEtzQMWYBPggZh/0cnOxPficw5cuK/YjjkehKoIN4YUaSh0UQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.20",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.23",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -1015,15 +1087,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
-      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1031,13 +1103,13 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.12.tgz",
-      "integrity": "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-hex-encoding": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -1046,13 +1118,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.12.tgz",
-      "integrity": "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
+      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1060,12 +1132,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.12.tgz",
-      "integrity": "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
+      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1073,13 +1145,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.12.tgz",
-      "integrity": "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
+      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1087,13 +1159,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.12.tgz",
-      "integrity": "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
+      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1101,14 +1173,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.15",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
-      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -1117,12 +1189,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
-      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -1132,12 +1204,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
-      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1157,13 +1229,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
-      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1171,18 +1243,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.27",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.27.tgz",
-      "integrity": "sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==",
+      "version": "4.4.30",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.30.tgz",
+      "integrity": "sha512-qS2XqhKeXmdZ4nEQ4cOxIczSP/Y91wPAHYuRwmWDCh975B7/57uxsm5d6sisnUThn2u2FwzMdJNM7AbO1YPsPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.12",
-        "@smithy/middleware-serde": "^4.2.15",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/core": "^3.23.15",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1190,18 +1262,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.44",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.44.tgz",
-      "integrity": "sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.3.tgz",
+      "integrity": "sha512-TE8dJNi6JuxzGSxMCVd3i9IEWDndCl3bmluLsBNDWok8olgj65OfkndMhl9SZ7m14c+C5SQn/PcUmrDl57rSFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/service-error-classification": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.7",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
+        "@smithy/core": "^3.23.15",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
@@ -1210,14 +1283,14 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.15",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.15.tgz",
-      "integrity": "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==",
+      "version": "4.2.18",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.18.tgz",
+      "integrity": "sha512-M6CSgnp3v4tYz9ynj2JHbA60woBZcGqEwNjTKjBsNHPV26R1ZX52+0wW8WsZU18q45jD0tw2wL22S17Ze9LpEw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.23.15",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1225,12 +1298,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
-      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1238,14 +1311,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
-      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1253,15 +1326,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
-      "integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.3.tgz",
+      "integrity": "sha512-lc5jFL++x17sPhIwMWJ3YOnqmSjw/2Po6VLDlUIXvxVWRuJwRXnJ4jOBBLB0cfI5BB5ehIl02Fxr1PDvk/kxDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1269,12 +1341,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
-      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1282,12 +1354,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
-      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1295,12 +1367,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
-      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -1309,12 +1381,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
-      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1322,24 +1394,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
-      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.14.tgz",
+      "integrity": "sha512-vVimoUnGxlx4eLLQbZImdOZFOe+Zh+5ACntv8VxZuGP72LdWu5GV3oEmCahSEReBgRJoWjypFkrehSj7BWx1HQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1"
+        "@smithy/types": "^4.14.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
-      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1347,16 +1419,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
-      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.14",
         "@smithy/util-uri-escape": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -1366,17 +1438,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.7.tgz",
-      "integrity": "sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==",
+      "version": "4.12.11",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.11.tgz",
+      "integrity": "sha512-wzz/Wa1CH/Tlhxh0s4DQPEcXSxSVfJ59AZcUh9Gu0c6JTlKuwGf4o/3P2TExv0VbtPFt8odIBG+eQGK2+vTECg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.12",
-        "@smithy/middleware-endpoint": "^4.4.27",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.20",
+        "@smithy/core": "^3.23.15",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.23",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1384,9 +1456,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1396,13 +1468,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
-      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1473,14 +1545,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.43",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.43.tgz",
-      "integrity": "sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==",
+      "version": "4.3.47",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.47.tgz",
+      "integrity": "sha512-zlIuXai3/SHjQUQ8y3g/woLvrH573SK2wNjcDaHu5e9VOcC0JwM1MI0Sq0GZJyN3BwSUneIhpjZ18nsiz5AtQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.7",
-        "@smithy/types": "^4.13.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1488,17 +1560,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.47",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.47.tgz",
-      "integrity": "sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==",
+      "version": "4.2.52",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.52.tgz",
+      "integrity": "sha512-cQBz8g68Vnw1W2meXlkb3D/hXJU+Taiyj9P8qLJtjREEV9/Td65xi4A/H1sRQ8EIgX5qbZbvdYPKygKLholZ3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.7",
-        "@smithy/types": "^4.13.1",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1506,13 +1578,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
-      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.1.tgz",
+      "integrity": "sha512-wMxNDZJrgS5mQV9oxCs4TWl5767VMgOfqfZ3JHyCkMtGC2ykW9iPqMvFur695Otcc5yxLG8OKO/80tsQBxrhXg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1532,12 +1604,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
-      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1545,13 +1617,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.12.tgz",
-      "integrity": "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.2.tgz",
+      "integrity": "sha512-2+KTsJEwTi63NUv4uR9IQ+IFT1yu6Rf6JuoBK2WKaaJ/TRvOiOVGcXAsEqX/TQN2thR9yII21kPUJq1UV/WI2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/service-error-classification": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1559,14 +1631,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.20",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.20.tgz",
-      "integrity": "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==",
+      "version": "4.5.23",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.23.tgz",
+      "integrity": "sha512-N6on1+ngJ3RznZOnDWNveIwnTSlqxNnXuNAh7ez889ZZaRdXoNRTXKgmYOLe6dB0gCmAVtuRScE1hymQFl4hpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.0",
-        "@smithy/types": "^4.13.1",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-hex-encoding": "^4.2.2",
@@ -1907,9 +1979,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -2316,9 +2388,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -2510,9 +2582,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.700.0",
+    "@aws-sdk/client-cloudwatch-logs": "^3.700.0",
     "@aws-sdk/client-dynamodb": "^3.700.0",
     "@aws-sdk/client-ses": "^3.700.0",
     "@aws-sdk/lib-dynamodb": "^3.700.0",

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -14,6 +14,7 @@ import { generateUserId } from './lib/crypto.js';
 import { hashPassword } from './lib/password.js';
 import { ADMIN_EMAIL, ADMIN_PASSWORD } from './config.js';
 import { seedDefaultContent } from './lib/seed.js';
+import { logger } from './lib/logger.js';
 
 const server = new Hono();
 
@@ -71,7 +72,12 @@ server.route('/', app);
 server.notFound((c) => c.json({ error: 'Not found' }, 404));
 
 server.onError((err, c) => {
-  console.error('Unhandled error:', err);
+  logger.error('unhandled_error', {
+    path: c.req.path,
+    method: c.req.method,
+    error: err?.message || String(err),
+    stack: err?.stack,
+  });
   return c.json({ error: 'Internal server error' }, 500);
 });
 

--- a/server/src/lib/cloudwatch-logs.js
+++ b/server/src/lib/cloudwatch-logs.js
@@ -1,0 +1,81 @@
+// CloudWatch Logs reader for the /v1/admin/logs endpoint. Never swallows errors
+// silently — a failure populates `error` in the returned shape so callers
+// (plato-pilot in particular) can treat the outage as a distinct signal.
+
+const ERROR_PATTERN = '?ERROR ?Error ?error ?WARN ?warn ?TimeoutError ?"Task timed out"';
+const PER_GROUP_LIMIT = 100;
+
+function stage() {
+  return process.env.STAGE || 'prod';
+}
+
+function logGroupPrefix() {
+  return `/aws/lambda/plato-${stage()}-`;
+}
+
+function parseMessage(message) {
+  if (typeof message !== 'string') return null;
+  const trimmed = message.trim();
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return null;
+  try { return JSON.parse(trimmed); }
+  catch { return null; }
+}
+
+function normalizeEvent(event, logGroupName) {
+  const ts = new Date(event.timestamp).toISOString();
+  const parsed = parseMessage(event.message);
+  if (parsed && typeof parsed.code === 'string') {
+    const { level, code, ...meta } = parsed;
+    return {
+      logId: `cw_${event.eventId}`,
+      ts,
+      level: level === 'error' || level === 'warn' ? level : 'error',
+      code,
+      meta: { ...meta, logGroup: logGroupName, logStream: event.logStreamName },
+      source: 'cloudwatch',
+    };
+  }
+  return {
+    logId: `cw_${event.eventId}`,
+    ts,
+    level: 'error',
+    code: 'cloudwatch_raw',
+    meta: { message: event.message?.trim().slice(0, 2048), logGroup: logGroupName, logStream: event.logStreamName },
+    source: 'cloudwatch',
+  };
+}
+
+export async function fetchCloudWatchLogs({ since }) {
+  if (!process.env.AWS_REGION) {
+    return { entries: [], logGroups: [], error: 'AWS_REGION not set' };
+  }
+  let client;
+  try {
+    const mod = await import('@aws-sdk/client-cloudwatch-logs');
+    const { CloudWatchLogsClient, DescribeLogGroupsCommand, FilterLogEventsCommand } = mod;
+    client = new CloudWatchLogsClient({});
+    const prefix = logGroupPrefix();
+
+    const groupsRes = await client.send(new DescribeLogGroupsCommand({ logGroupNamePrefix: prefix, limit: 20 }));
+    const logGroups = (groupsRes.logGroups || []).map((g) => g.logGroupName).filter(Boolean);
+    if (!logGroups.length) {
+      return { entries: [], logGroups: [], error: null };
+    }
+
+    const startTime = since ? new Date(since).getTime() : Date.now() - 24 * 60 * 60 * 1000;
+    const perGroup = await Promise.all(logGroups.map(async (name) => {
+      const res = await client.send(new FilterLogEventsCommand({
+        logGroupName: name,
+        filterPattern: ERROR_PATTERN,
+        startTime,
+        limit: PER_GROUP_LIMIT,
+      }));
+      return (res.events || []).map((e) => normalizeEvent(e, name));
+    }));
+
+    const entries = perGroup.flat().sort((a, b) => b.ts.localeCompare(a.ts));
+    return { entries, logGroups, error: null };
+  } catch (err) {
+    return { entries: [], logGroups: [], error: err?.message || String(err) };
+  }
+}

--- a/server/src/lib/cloudwatch-logs.js
+++ b/server/src/lib/cloudwatch-logs.js
@@ -2,8 +2,13 @@
 // silently — a failure populates `error` in the returned shape so callers
 // (plato-pilot in particular) can treat the outage as a distinct signal.
 
-const ERROR_PATTERN = '?ERROR ?Error ?error ?WARN ?warn ?TimeoutError ?"Task timed out"';
-const PER_GROUP_LIMIT = 100;
+// CloudWatch filter patterns must have at least one required term; a pattern
+// where every term is optional (prefixed with `?`) matches ALL events. We run
+// two independent queries and merge — one for generic ERROR lines (which also
+// matches logger's structured emissions that Lambda prefixes with "ERROR"),
+// one for Lambda runtime timeouts that don't carry an ERROR prefix.
+const FILTER_PATTERNS = ['ERROR', '"Task timed out"'];
+const PER_PATTERN_LIMIT = 100;
 
 function stage() {
   return process.env.STAGE || 'prod';
@@ -15,19 +20,29 @@ function logGroupPrefix() {
 
 function parseMessage(message) {
   if (typeof message !== 'string') return null;
-  const trimmed = message.trim();
-  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return null;
-  try { return JSON.parse(trimmed); }
+  const start = message.indexOf('{');
+  const end = message.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) return null;
+  try { return JSON.parse(message.slice(start, end + 1)); }
   catch { return null; }
 }
 
-function normalizeEvent(event, logGroupName) {
+// Lambda-internal noise we never want to surface as errors.
+function isLifecycleLine(message) {
+  if (typeof message !== 'string') return false;
+  return /^(START|END|REPORT|INIT_START|EXTENSION) /.test(message.trim());
+}
+
+export function normalizeEvent(event, logGroupName) {
+  if (isLifecycleLine(event.message)) return null;
   const ts = new Date(event.timestamp).toISOString();
   const parsed = parseMessage(event.message);
   if (parsed && typeof parsed.code === 'string') {
-    const { level, code, ...meta } = parsed;
+    const { logId, level, code, ...meta } = parsed;
     return {
-      logId: `cw_${event.eventId}`,
+      // Use the original logId emitted by the logger so the endpoint can
+      // dedupe against the in-process ring buffer.
+      logId: logId || `cw_${event.eventId}`,
       ts,
       level: level === 'error' || level === 'warn' ? level : 'error',
       code,
@@ -49,11 +64,10 @@ export async function fetchCloudWatchLogs({ since }) {
   if (!process.env.AWS_REGION) {
     return { entries: [], logGroups: [], error: 'AWS_REGION not set' };
   }
-  let client;
   try {
     const mod = await import('@aws-sdk/client-cloudwatch-logs');
     const { CloudWatchLogsClient, DescribeLogGroupsCommand, FilterLogEventsCommand } = mod;
-    client = new CloudWatchLogsClient({});
+    const client = new CloudWatchLogsClient({});
     const prefix = logGroupPrefix();
 
     const groupsRes = await client.send(new DescribeLogGroupsCommand({ logGroupNamePrefix: prefix, limit: 20 }));
@@ -63,17 +77,25 @@ export async function fetchCloudWatchLogs({ since }) {
     }
 
     const startTime = since ? new Date(since).getTime() : Date.now() - 24 * 60 * 60 * 1000;
-    const perGroup = await Promise.all(logGroups.map(async (name) => {
+    const queries = logGroups.flatMap((name) =>
+      FILTER_PATTERNS.map((pattern) => ({ name, pattern })),
+    );
+    const results = await Promise.all(queries.map(async ({ name, pattern }) => {
       const res = await client.send(new FilterLogEventsCommand({
         logGroupName: name,
-        filterPattern: ERROR_PATTERN,
+        filterPattern: pattern,
         startTime,
-        limit: PER_GROUP_LIMIT,
+        limit: PER_PATTERN_LIMIT,
       }));
-      return (res.events || []).map((e) => normalizeEvent(e, name));
+      return (res.events || []).map((e) => normalizeEvent(e, name)).filter(Boolean);
     }));
 
-    const entries = perGroup.flat().sort((a, b) => b.ts.localeCompare(a.ts));
+    // Dedupe across pattern queries (same event can match both patterns).
+    const byEventId = new Map();
+    for (const entry of results.flat()) {
+      if (!byEventId.has(entry.logId)) byEventId.set(entry.logId, entry);
+    }
+    const entries = [...byEventId.values()].sort((a, b) => b.ts.localeCompare(a.ts));
     return { entries, logGroups, error: null };
   } catch (err) {
     return { entries: [], logGroups: [], error: err?.message || String(err) };

--- a/server/src/lib/logger.js
+++ b/server/src/lib/logger.js
@@ -1,0 +1,116 @@
+// Ring-buffer logger. Primary consumer is the plato-pilot agent via /v1/admin/logs.
+// Logs are keyed by a stable snake_case `code` (not free-form messages) so the
+// agent can group and count errors. Each call also writes structured JSON to
+// stdout, which Lambda forwards to CloudWatch — that's the second source the
+// endpoint merges in.
+
+const DEFAULT_SIZE = 500;
+const MAX_META_BYTES = 2048;
+const MAX_STACK_FRAMES = 10;
+
+function bufferSize() {
+  const n = parseInt(process.env.LOG_BUFFER_SIZE, 10);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_SIZE;
+}
+
+const buffer = [];
+let cursor = 0;
+
+function coerceCode(raw) {
+  if (typeof raw !== 'string' || !raw.length) return 'unknown';
+  const clean = raw.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+  return clean || 'unknown';
+}
+
+function truncateStack(stack) {
+  if (typeof stack !== 'string') return stack;
+  return stack.split('\n').slice(0, MAX_STACK_FRAMES).join('\n');
+}
+
+function sanitizeMeta(meta) {
+  if (!meta || typeof meta !== 'object') return {};
+  const out = { ...meta };
+  if (typeof out.stack === 'string') out.stack = truncateStack(out.stack);
+  try {
+    const serialized = JSON.stringify(out);
+    if (serialized.length <= MAX_META_BYTES) return out;
+    return { _truncated: true, preview: serialized.slice(0, MAX_META_BYTES) };
+  } catch {
+    return { _unserializable: true };
+  }
+}
+
+function nextLogId() {
+  return `log_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function push(level, rawCode, rawMeta) {
+  const originalCode = typeof rawCode === 'string' ? rawCode : '';
+  const code = coerceCode(originalCode);
+  const meta = sanitizeMeta(rawMeta);
+  const entry = { logId: nextLogId(), ts: new Date().toISOString(), level, code, meta };
+
+  const size = bufferSize();
+  if (buffer.length < size) {
+    buffer.push(entry);
+  } else {
+    buffer[cursor] = entry;
+    cursor = (cursor + 1) % size;
+  }
+
+  // Mirror to stdout as structured JSON so Lambda → CloudWatch captures the
+  // same shape. The endpoint can reconstruct a `code` from CloudWatch events
+  // that were emitted through the logger.
+  const payload = JSON.stringify({ level, code, ...meta });
+  if (level === 'error') console.error(payload);
+  else console.warn(payload);
+
+  // Surface code coercion as a separate warn event so misuse is visible.
+  if (originalCode && originalCode !== code) {
+    push('warn', 'logger_bad_code', { attempted: originalCode, coerced: code });
+  }
+}
+
+export const logger = {
+  error(code, meta) { push('error', code, meta); },
+  warn(code, meta) { push('warn', code, meta); },
+
+  recent({ since, level, limit = 200 } = {}) {
+    const sinceMs = since ? new Date(since).getTime() : 0;
+    const result = [];
+    for (const e of buffer) {
+      if (!e) continue;
+      if (level && e.level !== level) continue;
+      if (sinceMs && new Date(e.ts).getTime() < sinceMs) continue;
+      result.push(e);
+    }
+    result.sort((a, b) => b.ts.localeCompare(a.ts));
+    return result.slice(0, limit);
+  },
+
+  groups({ since, level } = {}) {
+    const entries = this.recent({ since, level, limit: bufferSize() });
+    const byCode = new Map();
+    for (const e of entries) {
+      const g = byCode.get(e.code);
+      if (!g) {
+        byCode.set(e.code, { code: e.code, level: e.level, count: 1, firstSeen: e.ts, lastSeen: e.ts, sources: ['buffer'], sample: e });
+      } else {
+        g.count++;
+        if (e.ts < g.firstSeen) g.firstSeen = e.ts;
+        if (e.ts > g.lastSeen) { g.lastSeen = e.ts; g.sample = e; }
+      }
+    }
+    return [...byCode.values()].sort((a, b) => b.count - a.count);
+  },
+
+  // Test-only: reset state between test cases.
+  _reset() {
+    buffer.length = 0;
+    cursor = 0;
+  },
+
+  _bufferSize: bufferSize,
+};
+
+export default logger;

--- a/server/src/lib/logger.js
+++ b/server/src/lib/logger.js
@@ -59,9 +59,9 @@ function push(level, rawCode, rawMeta) {
   }
 
   // Mirror to stdout as structured JSON so Lambda → CloudWatch captures the
-  // same shape. The endpoint can reconstruct a `code` from CloudWatch events
-  // that were emitted through the logger.
-  const payload = JSON.stringify({ level, code, ...meta });
+  // same shape. logId is included so the endpoint can dedupe when the same
+  // event is retrieved from both the buffer and CloudWatch.
+  const payload = JSON.stringify({ logId: entry.logId, level, code, ...meta });
   if (level === 'error') console.error(payload);
   else console.warn(payload);
 

--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -792,14 +792,32 @@ admin.get('/v1/admin/logs', async (c) => {
     cwEntries = (cw.entries || []).filter((e) => !level || e.level === level);
   }
 
-  // Merge, dedupe by logId, sort newest-first.
-  const merged = new Map();
-  for (const e of [...bufferEntries, ...cwEntries]) merged.set(e.logId, e);
-  const entries = [...merged.values()].sort((a, b) => b.ts.localeCompare(a.ts));
+  // Merge, dedupe by logId (logger emits logId to stdout so events appearing
+  // in both the buffer and CloudWatch share an ID). Track per-logId sources
+  // so groups can report "buffer", "cloudwatch", or both accurately.
+  const byLogId = new Map();
+  const sourcesByLogId = new Map();
+  function recordSource(logId, source) {
+    let set = sourcesByLogId.get(logId);
+    if (!set) { set = new Set(); sourcesByLogId.set(logId, set); }
+    set.add(source);
+  }
+  for (const e of bufferEntries) {
+    byLogId.set(e.logId, e); // buffer wins on meta
+    recordSource(e.logId, 'buffer');
+  }
+  for (const e of cwEntries) {
+    if (!byLogId.has(e.logId)) byLogId.set(e.logId, e);
+    recordSource(e.logId, 'cloudwatch');
+  }
+  const entries = [...byLogId.values()]
+    .map((e) => ({ ...e, source: [...sourcesByLogId.get(e.logId)].join('+') }))
+    .sort((a, b) => b.ts.localeCompare(a.ts));
 
   // Build groups across both sources.
   const groups = new Map();
   for (const e of entries) {
+    const srcSet = sourcesByLogId.get(e.logId);
     const g = groups.get(e.code);
     if (!g) {
       groups.set(e.code, {
@@ -808,14 +826,14 @@ admin.get('/v1/admin/logs', async (c) => {
         count: 1,
         firstSeen: e.ts,
         lastSeen: e.ts,
-        sources: [e.source],
+        sources: [...srcSet],
         sample: e,
       });
     } else {
       g.count++;
       if (e.ts < g.firstSeen) g.firstSeen = e.ts;
       if (e.ts > g.lastSeen) { g.lastSeen = e.ts; g.sample = e; }
-      if (!g.sources.includes(e.source)) g.sources.push(e.source);
+      for (const s of srcSet) if (!g.sources.includes(s)) g.sources.push(s);
     }
   }
   const groupsList = [...groups.values()].sort((a, b) => b.count - a.count);

--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -8,6 +8,8 @@ import { testSlackConnection, searchSlackUsers, listSlackChannels, listChannelMe
 import { APP_URL } from '../config.js';
 import { validateUsername } from './auth.js';
 import { MIN_OBJECTIVES, MAX_OBJECTIVES, MAX_EXCHANGES } from '../lib/lesson-limits.js';
+import { logger } from '../lib/logger.js';
+import { fetchCloudWatchLogs } from '../lib/cloudwatch-logs.js';
 
 const admin = new Hono();
 
@@ -754,6 +756,87 @@ admin.get('/v1/admin/stats/lessons', async (c) => {
     avgDurationMinutes,
     activeLessons,
   });
+});
+
+// GET /v1/admin/logs — recent server errors/warnings for the pilot agent.
+// Merges in-process ring buffer with CloudWatch (default on). Failures from
+// CloudWatch populate `cloudwatch.error` rather than silently returning empty.
+admin.get('/v1/admin/logs', async (c) => {
+  const url = new URL(c.req.url);
+  const rawSince = url.searchParams.get('since');
+  const levelParam = url.searchParams.get('level');
+  const limitParam = parseInt(url.searchParams.get('limit') || '200', 10);
+  const cloudwatchParam = url.searchParams.get('cloudwatch');
+  const view = url.searchParams.get('view') || 'both';
+
+  const level = levelParam === 'error' || levelParam === 'warn' ? levelParam : undefined;
+  const limit = Math.min(Math.max(Number.isFinite(limitParam) ? limitParam : 200, 1), 1000);
+  const includeCloudWatch = cloudwatchParam !== '0';
+
+  let since;
+  if (rawSince) {
+    const t = new Date(rawSince).getTime();
+    if (!Number.isFinite(t)) return c.json({ error: 'Invalid since parameter' }, 400);
+    since = new Date(t).toISOString();
+  } else {
+    since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  }
+
+  const bufferEntries = logger.recent({ since, level, limit: logger._bufferSize() }).map((e) => ({ ...e, source: 'buffer' }));
+
+  let cloudwatch = { logGroups: [], error: null };
+  let cwEntries = [];
+  if (includeCloudWatch) {
+    const cw = await fetchCloudWatchLogs({ since });
+    cloudwatch = { logGroups: cw.logGroups, error: cw.error };
+    cwEntries = (cw.entries || []).filter((e) => !level || e.level === level);
+  }
+
+  // Merge, dedupe by logId, sort newest-first.
+  const merged = new Map();
+  for (const e of [...bufferEntries, ...cwEntries]) merged.set(e.logId, e);
+  const entries = [...merged.values()].sort((a, b) => b.ts.localeCompare(a.ts));
+
+  // Build groups across both sources.
+  const groups = new Map();
+  for (const e of entries) {
+    const g = groups.get(e.code);
+    if (!g) {
+      groups.set(e.code, {
+        code: e.code,
+        level: e.level,
+        count: 1,
+        firstSeen: e.ts,
+        lastSeen: e.ts,
+        sources: [e.source],
+        sample: e,
+      });
+    } else {
+      g.count++;
+      if (e.ts < g.firstSeen) g.firstSeen = e.ts;
+      if (e.ts > g.lastSeen) { g.lastSeen = e.ts; g.sample = e; }
+      if (!g.sources.includes(e.source)) g.sources.push(e.source);
+    }
+  }
+  const groupsList = [...groups.values()].sort((a, b) => b.count - a.count);
+
+  const counts = { error: 0, warn: 0 };
+  for (const e of entries) {
+    if (e.level === 'error' || e.level === 'warn') counts[e.level]++;
+  }
+
+  const windowMs = Date.now() - new Date(since).getTime();
+  const response = {
+    windowHours: +(windowMs / 3600000).toFixed(2),
+    since,
+    counts,
+    buffer: { size: logger._bufferSize(), used: bufferEntries.length },
+    cloudwatch,
+  };
+  if (view !== 'entries') response.groups = groupsList;
+  if (view !== 'groups') response.entries = entries.slice(0, limit);
+
+  return c.json(response);
 });
 
 export default admin;

--- a/server/template.yaml
+++ b/server/template.yaml
@@ -37,6 +37,7 @@ Resources:
           REFRESH_TOKENS_TABLE: !Ref RefreshTokensTable
           SYNC_DATA_TABLE: !Ref SyncDataTable
           AUDIT_LOG_TABLE: !Ref AuditLogTable
+          STAGE: !Ref Stage
           JWT_SECRET: !Sub '{{resolve:ssm:/plato/${Stage}/jwt-secret}}'
           ADMIN_EMAIL: !Sub '{{resolve:ssm:/plato/${Stage}/admin-email}}'
           ADMIN_PASSWORD: !Sub '{{resolve:ssm:/plato/${Stage}/admin-password}}'
@@ -63,6 +64,12 @@ Resources:
                 - bedrock:InvokeModel
                 - bedrock:InvokeModelWithResponseStream
               Resource: '*'
+        - Statement:
+            - Effect: Allow
+              Action:
+                - logs:FilterLogEvents
+                - logs:DescribeLogGroups
+              Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/plato-${Stage}-*"
       Events:
         ApiCatchAll:
           Type: HttpApi
@@ -83,6 +90,7 @@ Resources:
           REFRESH_TOKENS_TABLE: !Ref RefreshTokensTable
           SYNC_DATA_TABLE: !Ref SyncDataTable
           AUDIT_LOG_TABLE: !Ref AuditLogTable
+          STAGE: !Ref Stage
           JWT_SECRET: !Sub '{{resolve:ssm:/plato/${Stage}/jwt-secret}}'
           ADMIN_EMAIL: !Sub '{{resolve:ssm:/plato/${Stage}/admin-email}}'
           ADMIN_PASSWORD: !Sub '{{resolve:ssm:/plato/${Stage}/admin-password}}'
@@ -109,6 +117,12 @@ Resources:
                 - bedrock:InvokeModel
                 - bedrock:InvokeModelWithResponseStream
               Resource: '*'
+        - Statement:
+            - Effect: Allow
+              Action:
+                - logs:FilterLogEvents
+                - logs:DescribeLogGroups
+              Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/plato-${Stage}-*"
       FunctionUrlConfig:
         AuthType: NONE
         InvokeMode: RESPONSE_STREAM

--- a/server/tests/lib/cloudwatch-logs.test.js
+++ b/server/tests/lib/cloudwatch-logs.test.js
@@ -1,0 +1,46 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeEvent } from '../../src/lib/cloudwatch-logs.js';
+
+describe('normalizeEvent', () => {
+  it('preserves the logger-emitted logId so buffer + CloudWatch dedupe', () => {
+    // The logger writes `{"logId":"log_123...","level":"error","code":"unhandled_error",...}`
+    // to stdout. Lambda forwards that line into CloudWatch. When the endpoint
+    // pulls the event back, normalizeEvent must use the *same* logId so the
+    // merge-by-logId step in admin.js coalesces the two sources.
+    const event = {
+      eventId: 'cw-event-42',
+      timestamp: Date.parse('2026-04-17T14:00:00Z'),
+      logStreamName: 'stream/abc',
+      message: '2026-04-17T14:00:00.123Z\tabc-req-id\tERROR\t{"logId":"log_1111_abcxyz","level":"error","code":"unhandled_error","path":"/x"}',
+    };
+    const normalized = normalizeEvent(event, '/aws/lambda/plato-prod-api');
+    assert.equal(normalized.logId, 'log_1111_abcxyz');
+    assert.equal(normalized.code, 'unhandled_error');
+    assert.equal(normalized.level, 'error');
+    assert.equal(normalized.source, 'cloudwatch');
+    assert.equal(normalized.meta.path, '/x');
+    assert.equal(normalized.meta.logGroup, '/aws/lambda/plato-prod-api');
+  });
+
+  it('falls back to cw_* id and cloudwatch_raw code for unstructured lines', () => {
+    const event = {
+      eventId: 'cw-event-99',
+      timestamp: Date.parse('2026-04-17T14:00:00Z'),
+      logStreamName: 'stream/abc',
+      message: '2026-04-17T14:00:00.000Z  abc-req  Task timed out after 30.02 seconds',
+    };
+    const normalized = normalizeEvent(event, '/aws/lambda/plato-prod-stream');
+    assert.equal(normalized.logId, 'cw_cw-event-99');
+    assert.equal(normalized.code, 'cloudwatch_raw');
+    assert.equal(normalized.level, 'error');
+    assert.ok(normalized.meta.message.includes('Task timed out'));
+  });
+
+  it('returns null for Lambda lifecycle noise (START/END/REPORT)', () => {
+    for (const msg of ['START RequestId: abc Version: $LATEST', 'END RequestId: abc', 'REPORT RequestId: abc Duration: 12 ms', 'INIT_START Runtime Version: nodejs:20']) {
+      const event = { eventId: 'x', timestamp: Date.now(), logStreamName: 's', message: msg };
+      assert.equal(normalizeEvent(event, 'g'), null, `should drop: ${msg}`);
+    }
+  });
+});

--- a/server/tests/lib/logger.test.js
+++ b/server/tests/lib/logger.test.js
@@ -1,0 +1,100 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { logger } from '../../src/lib/logger.js';
+
+// Silence the stdout mirror so test output stays clean.
+const origErr = console.error;
+const origWarn = console.warn;
+console.error = () => {};
+console.warn = () => {};
+
+describe('logger', () => {
+  beforeEach(() => {
+    logger._reset();
+    delete process.env.LOG_BUFFER_SIZE;
+  });
+
+  it('stores entries in the ring buffer with stable code', () => {
+    logger.error('unhandled_error', { path: '/x' });
+    logger.warn('seed_failed', { error: 'oops' });
+    const entries = logger.recent();
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].code, 'seed_failed');
+    assert.equal(entries[1].code, 'unhandled_error');
+    assert.ok(entries[0].logId.startsWith('log_'));
+  });
+
+  it('coerces non-snake-case codes and emits logger_bad_code', () => {
+    logger.error('Unhandled Error!', { foo: 1 });
+    const entries = logger.recent();
+    const codes = entries.map((e) => e.code);
+    assert.ok(codes.includes('unhandled_error'));
+    assert.ok(codes.includes('logger_bad_code'));
+    const bad = entries.find((e) => e.code === 'logger_bad_code');
+    assert.equal(bad.meta.attempted, 'Unhandled Error!');
+    assert.equal(bad.meta.coerced, 'unhandled_error');
+  });
+
+  it('truncates stack traces to 10 frames', () => {
+    const frames = Array.from({ length: 30 }, (_, i) => `    at fn${i} (file.js:${i}:1)`).join('\n');
+    logger.error('big_stack', { stack: `Error: boom\n${frames}` });
+    const [entry] = logger.recent();
+    const lines = entry.meta.stack.split('\n');
+    assert.equal(lines.length, 10);
+  });
+
+  it('truncates meta larger than 2KB', () => {
+    const huge = 'x'.repeat(5000);
+    logger.error('big_meta', { blob: huge });
+    const [entry] = logger.recent();
+    assert.ok(entry.meta._truncated);
+    assert.ok(entry.meta.preview.length <= 2048);
+  });
+
+  it('evicts oldest entries when buffer is full', () => {
+    process.env.LOG_BUFFER_SIZE = '3';
+    logger._reset();
+    for (let i = 0; i < 5; i++) logger.error('evict_test', { i });
+    const entries = logger.recent();
+    assert.equal(entries.length, 3);
+    const iValues = entries.map((e) => e.meta.i).sort((a, b) => a - b);
+    assert.deepEqual(iValues, [2, 3, 4]);
+  });
+
+  it('filters recent() by level and since', async () => {
+    const mid = new Date().toISOString();
+    await new Promise((r) => setTimeout(r, 5));
+    logger.error('later_err');
+    logger.warn('later_warn');
+
+    const onlyErrors = logger.recent({ level: 'error' });
+    assert.equal(onlyErrors.length, 1);
+    assert.equal(onlyErrors[0].code, 'later_err');
+
+    const since = logger.recent({ since: mid });
+    assert.equal(since.length, 2);
+  });
+
+  it('groups() aggregates by code with count/firstSeen/lastSeen', async () => {
+    logger.error('ai_stream_error');
+    await new Promise((r) => setTimeout(r, 2));
+    logger.error('ai_stream_error');
+    await new Promise((r) => setTimeout(r, 2));
+    logger.error('unhandled_error');
+
+    const groups = logger.groups();
+    assert.equal(groups.length, 2);
+    assert.equal(groups[0].code, 'ai_stream_error');
+    assert.equal(groups[0].count, 2);
+    assert.ok(groups[0].firstSeen < groups[0].lastSeen);
+    assert.equal(groups[0].sources[0], 'buffer');
+    assert.equal(groups[1].code, 'unhandled_error');
+    assert.equal(groups[1].count, 1);
+  });
+});
+
+// Restore console for subsequent test files.
+process.on('exit', () => {
+  console.error = origErr;
+  console.warn = origWarn;
+});

--- a/server/tests/routes/admin.test.js
+++ b/server/tests/routes/admin.test.js
@@ -552,4 +552,5 @@ describe('GET /v1/admin/logs', () => {
     assert.equal(data.cloudwatch.error, null);
     assert.deepEqual(data.cloudwatch.logGroups, []);
   });
+
 });

--- a/server/tests/routes/admin.test.js
+++ b/server/tests/routes/admin.test.js
@@ -4,6 +4,7 @@ import { Hono } from 'hono';
 import admin from '../../src/routes/admin.js';
 import db from '../../src/lib/db.js';
 import { signAccessToken } from '../../src/lib/jwt.js';
+import { logger } from '../../src/lib/logger.js';
 
 async function adminReq(app, method, path, body) {
   const token = await signAccessToken('usr_admin', 'admin');
@@ -448,5 +449,107 @@ describe('PUT /v1/admin/lessons/:lessonId — sharedWith + public/private', () =
     const data = await res.json();
     assert.equal(data[0].status, 'private');
     assert.deepEqual(data[0].sharedWith, ['usr_1', 'usr_2']);
+  });
+});
+
+describe('GET /v1/admin/logs', () => {
+  const origConsoleErr = console.error;
+  const origConsoleWarn = console.warn;
+  let savedRegion;
+
+  beforeEach(() => {
+    db.getUserById = async (id) => {
+      if (id === 'usr_admin') return { userId: 'usr_admin', role: 'admin', name: 'Admin' };
+      if (id === 'usr_user') return { userId: 'usr_user', role: 'user' };
+      return null;
+    };
+    logger._reset();
+    console.error = () => {};
+    console.warn = () => {};
+    savedRegion = process.env.AWS_REGION;
+    delete process.env.AWS_REGION; // force cloudwatch error path
+  });
+
+  afterEach(() => {
+    console.error = origConsoleErr;
+    console.warn = origConsoleWarn;
+    if (savedRegion !== undefined) process.env.AWS_REGION = savedRegion;
+  });
+
+  it('rejects non-admin', async () => {
+    const app = new Hono(); app.route('/', admin);
+    const res = await userReq(app, 'GET', '/v1/admin/logs');
+    assert.equal(res.status, 403);
+  });
+
+  it('returns captured errors from the ring buffer', async () => {
+    logger.error('unhandled_error', { path: '/foo' });
+    logger.error('unhandled_error', { path: '/bar' });
+    logger.warn('seed_failed', { error: 'x' });
+
+    const app = new Hono(); app.route('/', admin);
+    const res = await adminReq(app, 'GET', '/v1/admin/logs');
+    assert.equal(res.status, 200);
+    const data = await res.json();
+
+    assert.equal(data.counts.error, 2);
+    assert.equal(data.counts.warn, 1);
+    assert.ok(Array.isArray(data.groups));
+    const unhandled = data.groups.find((g) => g.code === 'unhandled_error');
+    assert.equal(unhandled.count, 2);
+    assert.deepEqual(unhandled.sources, ['buffer']);
+  });
+
+  it('filters by level', async () => {
+    logger.error('unhandled_error');
+    logger.warn('seed_failed');
+
+    const app = new Hono(); app.route('/', admin);
+    const res = await adminReq(app, 'GET', '/v1/admin/logs?level=error');
+    const data = await res.json();
+    const codes = data.entries.map((e) => e.code);
+    assert.ok(codes.includes('unhandled_error'));
+    assert.ok(!codes.includes('seed_failed'));
+  });
+
+  it('view=groups omits raw entries', async () => {
+    logger.error('unhandled_error');
+    const app = new Hono(); app.route('/', admin);
+    const res = await adminReq(app, 'GET', '/v1/admin/logs?view=groups');
+    const data = await res.json();
+    assert.ok(data.groups);
+    assert.equal(data.entries, undefined);
+  });
+
+  it('view=entries omits groups', async () => {
+    logger.error('unhandled_error');
+    const app = new Hono(); app.route('/', admin);
+    const res = await adminReq(app, 'GET', '/v1/admin/logs?view=entries');
+    const data = await res.json();
+    assert.ok(data.entries);
+    assert.equal(data.groups, undefined);
+  });
+
+  it('400 on invalid since', async () => {
+    const app = new Hono(); app.route('/', admin);
+    const res = await adminReq(app, 'GET', '/v1/admin/logs?since=not-a-date');
+    assert.equal(res.status, 400);
+  });
+
+  it('surfaces CloudWatch failure explicitly instead of silently empty', async () => {
+    // AWS_REGION is unset in beforeEach, so the SDK path returns an error.
+    const app = new Hono(); app.route('/', admin);
+    const res = await adminReq(app, 'GET', '/v1/admin/logs');
+    const data = await res.json();
+    assert.equal(data.cloudwatch.error, 'AWS_REGION not set');
+    assert.deepEqual(data.cloudwatch.logGroups, []);
+  });
+
+  it('cloudwatch=0 skips the AWS call', async () => {
+    const app = new Hono(); app.route('/', admin);
+    const res = await adminReq(app, 'GET', '/v1/admin/logs?cloudwatch=0');
+    const data = await res.json();
+    assert.equal(data.cloudwatch.error, null);
+    assert.deepEqual(data.cloudwatch.logGroups, []);
   });
 });


### PR DESCRIPTION
## Summary

New admin endpoint the plato-pilot agent will call to read recent server errors. Backed by two independent sources — an in-process ring buffer populated by a new `logger` utility, plus CloudWatch Logs queried from within the Lambda (using its own IAM role, not GitHub Actions). This is **PR 1 of 2**: server side only, no pilot-side changes yet so the current workflow keeps running unchanged.

## What's in here

- `server/src/lib/logger.js` — ring-buffer logger keyed by snake_case `code` strings (e.g. `unhandled_error`, `ai_stream_error`). Each call also emits structured JSON to stdout so Lambda → CloudWatch sees the same shape.
- `server/src/lib/cloudwatch-logs.js` — thin wrapper around `@aws-sdk/client-cloudwatch-logs`. Never swallows errors silently — a failure populates `cloudwatch.error` in the response.
- `GET /v1/admin/logs` — admin-authenticated endpoint under the existing `requireAdmin` middleware. Params: `since`, `level`, `limit`, `cloudwatch` (default on), `view` (`groups` | `entries` | `both`). Response includes a pre-aggregated `groups` lane sorted by count — the agent reads this instead of parsing 500 individual entries.
- `server/src/index.js` — replaces `console.error` in the onError catch-all with `logger.error('unhandled_error', ...)`. Covers the catch-all path that handles every unhandled error anywhere in the app.
- `server/template.yaml` — adds `logs:FilterLogEvents` + `logs:DescribeLogGroups` IAM grant scoped to `/aws/lambda/plato-${Stage}-*` on both Lambda functions. Adds `STAGE` env var so the Lambda knows which log group prefix to use.
- `server/package.json` — adds `@aws-sdk/client-cloudwatch-logs`.

## Tests

- `server/tests/lib/logger.test.js` (new) — 7 tests: buffer/eviction/filter, code coercion, stack truncation, 2KB meta cap, groups aggregation.
- `server/tests/routes/admin.test.js` — 8 new tests for the endpoint: non-admin 403, buffer reads, level filter, view modes, invalid `since` → 400, `cloudwatch.error` populated on SDK failure (never silent-empty), `cloudwatch=0` skips AWS.
- All 119 tests pass (`cd server && npm test`).

## What's NOT in here

- **No pilot-side change.** `scripts/pilot-report.js` still uses AWS CLI. It'll stay broken in the same way it is today until PR 2 lands.
- **No DynamoDB `app-log` table.** CloudWatch already captures every `console.error` the app makes; a separate table would be redundant.
- **No migration of other `console.error` calls.** The catch-all handler covers ~every unhandled error. Individual call sites can migrate to named codes incrementally.

## Test plan

- [ ] CI green
- [ ] After deploy to prod: `curl -H "Authorization: Bearer <admin-token>" https://learn.ai-leaders.org/v1/admin/logs?limit=5` returns valid JSON with `groups`, `entries`, `cloudwatch.logGroups` populated
- [ ] Trigger a synthetic error on an unknown route, confirm it appears under `groups` with `code: "unhandled_error"`
- [ ] Then land PR 2 (pilot-side switch) on a Fri/Sat so Sunday's cron exercises the new path