### PR TITLE
Deterministic logger ordering (fixes prod deploy)

### DIFF
--- a/server/src/lib/logger.js
+++ b/server/src/lib/logger.js
@@ -15,6 +15,7 @@ function bufferSize() {
 
 const buffer = [];
 let cursor = 0;
+let seq = 0;
 
 function coerceCode(raw) {
   if (typeof raw !== 'string' || !raw.length) return 'unknown';
@@ -48,7 +49,10 @@ function push(level, rawCode, rawMeta) {
   const originalCode = typeof rawCode === 'string' ? rawCode : '';
   const code = coerceCode(originalCode);
   const meta = sanitizeMeta(rawMeta);
-  const entry = { logId: nextLogId(), ts: new Date().toISOString(), level, code, meta };
+  // `seq` provides a monotonic ordering that doesn't collapse when multiple
+  // entries land within the same millisecond (which ts alone does on fast
+  // runners — CI hits this routinely).
+  const entry = { logId: nextLogId(), seq: ++seq, ts: new Date().toISOString(), level, code, meta };
 
   const size = bufferSize();
   if (buffer.length < size) {
@@ -84,7 +88,8 @@ export const logger = {
       if (sinceMs && new Date(e.ts).getTime() < sinceMs) continue;
       result.push(e);
     }
-    result.sort((a, b) => b.ts.localeCompare(a.ts));
+    // Newest first. Use ts primarily, fall back to seq for same-ms ties.
+    result.sort((a, b) => b.ts.localeCompare(a.ts) || b.seq - a.seq);
     return result.slice(0, limit);
   },
 
@@ -108,6 +113,7 @@ export const logger = {
   _reset() {
     buffer.length = 0;
     cursor = 0;
+    seq = 0;
   },
 
   _bufferSize: bufferSize,


### PR DESCRIPTION
## Summary

Hotfix: the logger test ordering is timing-dependent. Two synchronous calls on a fast runner get the same ms-precision \`ts\`, and the ts-based sort in \`recent()\` collapses — CI put entries in a different order than my local run, so \`logger.test.js:22\` (\`expected 'seed_failed', got 'unhandled_error'\`) failed. This blocked the prod deploy triggered by #63's merge.

Fix: each entry now carries a monotonic \`seq\` counter; \`recent()\` sorts by ts first, seq as a tiebreaker. Deterministic regardless of clock resolution.

## Test plan

- [ ] CI green
- [ ] Auto-deploy to prod succeeds