### PR TITLE
Switch pilot to /v1/admin/logs

### DIFF
--- a/.github/workflows/pilot.yml
+++ b/.github/workflows/pilot.yml
@@ -12,7 +12,6 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -21,15 +20,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - uses: aws-actions/configure-aws-credentials@v4
-        if: ${{ env.AWS_ROLE_ARN != '' }}
-        continue-on-error: true
-        env:
-          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-2
 
       - name: Generate pilot report
         id: report
@@ -52,12 +42,14 @@ jobs:
             You have a turn budget — be efficient. Don't over-explore. Pick one thing, fix it, test it, ship it.
 
             ## Step 1: Read context (≤5 turns)
-            - Read /tmp/pilot-report.md for today's KPI snapshot and CloudWatch logs
+            - Read /tmp/pilot-report.md for today's KPI snapshot and server errors (by code, with counts and samples)
             - Read CLAUDE.md for architecture and conventions
             - Run `gh issue list --state open --limit 20` to see current issues
 
             ## Step 2: Triage — pick ONE thing (1 turn)
-            Priority: errors in logs > KPI regression (on-target <75%) > bug issues > enhancement issues > skip.
+            Priority: high-count error codes > KPI regression (on-target <75%) > bug issues > enhancement issues > skip.
+            The errors table is keyed by `code` (e.g. `unhandled_error`, `ai_stream_error`, `cloudwatch_raw`) with counts and first/last seen. Pick the code with the highest count that looks actionable.
+            If the report shows `CloudWatch fetch failed`, the in-process buffer errors are still reliable but Lambda runtime errors (timeouts etc.) may be missing — factor that uncertainty in.
             If an issue and a log error overlap, that's the strongest signal.
             If nothing is actionable, stop immediately — do not invent work.
 

--- a/scripts/pilot-report.js
+++ b/scripts/pilot-report.js
@@ -46,7 +46,9 @@ function formatGroups(logs) {
   if (!logs.groups?.length) return 'No errors or warnings in the last 24h.';
   const rows = logs.groups.map((g) => {
     const sample = g.sample?.meta?.error || g.sample?.meta?.message || '';
-    const preview = sample.toString().replace(/\s+/g, ' ').slice(0, 120);
+    // Escape pipes so error messages containing `|` don't break the markdown
+    // table columns (the pilot agent reads these rows directly).
+    const preview = sample.toString().replace(/\s+/g, ' ').replace(/\|/g, '\\|').slice(0, 120);
     return `| \`${g.code}\` | ${g.level} | ${g.count} | ${g.firstSeen} | ${g.lastSeen} | ${g.sources.join(', ')} | ${preview} |`;
   });
   return [

--- a/scripts/pilot-report.js
+++ b/scripts/pilot-report.js
@@ -1,29 +1,19 @@
 #!/usr/bin/env node
 
 /**
- * Collects KPIs from plato's admin API and CloudWatch logs (via AWS CLI),
- * then outputs a markdown triage report for the pilot workflow.
+ * Collects KPIs and server logs from plato's admin API, then outputs a
+ * markdown triage report for the pilot workflow.
  *
  * Required env vars:
  *   PLATO_API_URL          — e.g. https://learn.ai-leaders.org
  *   PLATO_ADMIN_EMAIL      — admin email for API login
  *   PLATO_ADMIN_PASSWORD   — admin password for API login
- *   AWS_REGION             — set by configure-aws-credentials
  *
  * Usage: node scripts/pilot-report.js > /tmp/pilot-report.md
  */
 
-import { execSync } from 'node:child_process';
-
-// ---------------------------------------------------------------------------
-// KPIs via plato API
-// ---------------------------------------------------------------------------
-
-async function collectKpis() {
-  const apiUrl = process.env.PLATO_API_URL;
-  if (!apiUrl) throw new Error('PLATO_API_URL is required');
-
-  const loginRes = await fetch(`${apiUrl}/v1/auth/login`, {
+async function login(apiUrl) {
+  const res = await fetch(`${apiUrl}/v1/auth/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -31,87 +21,55 @@ async function collectKpis() {
       password: process.env.PLATO_ADMIN_PASSWORD,
     }),
   });
-  if (!loginRes.ok) throw new Error(`Login failed: ${loginRes.status}`);
-  const { accessToken } = await loginRes.json();
+  if (!res.ok) throw new Error(`Login failed: ${res.status}`);
+  const { accessToken } = await res.json();
+  return accessToken;
+}
 
-  const statsRes = await fetch(`${apiUrl}/v1/admin/stats/lessons`, {
-    headers: { Authorization: `Bearer ${accessToken}` },
+async function collectKpis(apiUrl, token) {
+  const res = await fetch(`${apiUrl}/v1/admin/stats/lessons`, {
+    headers: { Authorization: `Bearer ${token}` },
   });
-  if (!statsRes.ok) throw new Error(`Stats API failed: ${statsRes.status}`);
-  return statsRes.json();
+  if (!res.ok) throw new Error(`Stats API failed: ${res.status}`);
+  return res.json();
 }
 
-// ---------------------------------------------------------------------------
-// CloudWatch logs via AWS CLI
-// ---------------------------------------------------------------------------
-
-function collectLogs() {
-  const windowMs = 24 * 60 * 60 * 1000;
-  const startTime = Date.now() - windowMs;
-  const noLogs = { errors: [], activity: [], logGroups: [], windowHours: 24 };
-
-  // Check if AWS CLI is available and configured
-  try {
-    execSync('aws sts get-caller-identity', { encoding: 'utf-8', timeout: 10000, stdio: 'pipe' });
-  } catch {
-    console.error('AWS credentials not available — skipping CloudWatch logs');
-    return noLogs;
-  }
-
-  // Find plato log groups
-  let logGroups = [];
-  try {
-    const raw = execSync(
-      `aws logs describe-log-groups --log-group-name-prefix /aws/lambda/plato- --query "logGroups[].logGroupName" --output json`,
-      { encoding: 'utf-8', timeout: 30000 },
-    );
-    logGroups = JSON.parse(raw);
-  } catch {
-    return noLogs;
-  }
-
-  const errors = [];
-  const activity = [];
-
-  for (const logGroup of logGroups) {
-    try {
-      const errRaw = execSync(
-        `aws logs filter-log-events --log-group-name "${logGroup}" --start-time ${startTime} --filter-pattern '?ERROR ?Error ?error ?WARN ?warn ?TimeoutError ?"Task timed out"' --limit 50 --query "events[].{timestamp:timestamp,message:message}" --output json`,
-        { encoding: 'utf-8', timeout: 30000 },
-      );
-      for (const event of JSON.parse(errRaw)) {
-        errors.push({
-          logGroup,
-          timestamp: new Date(event.timestamp).toISOString(),
-          message: event.message.trim().slice(0, 500),
-        });
-      }
-    } catch { /* empty or inaccessible */ }
-
-    try {
-      const actRaw = execSync(
-        `aws logs filter-log-events --log-group-name "${logGroup}" --start-time ${startTime} --limit 20 --query "events[].{timestamp:timestamp,message:message}" --output json`,
-        { encoding: 'utf-8', timeout: 30000 },
-      );
-      for (const event of JSON.parse(actRaw)) {
-        activity.push({
-          logGroup,
-          timestamp: new Date(event.timestamp).toISOString(),
-          message: event.message.trim().slice(0, 300),
-        });
-      }
-    } catch { /* empty or inaccessible */ }
-  }
-
-  return { errors, activity, logGroups, windowHours: 24 };
+async function collectLogs(apiUrl, token) {
+  const res = await fetch(`${apiUrl}/v1/admin/logs?view=groups`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`Logs API failed: ${res.status}`);
+  return res.json();
 }
 
-// ---------------------------------------------------------------------------
-// Report
-// ---------------------------------------------------------------------------
+function formatGroups(logs) {
+  if (!logs.groups?.length) return 'No errors or warnings in the last 24h.';
+  const rows = logs.groups.map((g) => {
+    const sample = g.sample?.meta?.error || g.sample?.meta?.message || '';
+    const preview = sample.toString().replace(/\s+/g, ' ').slice(0, 120);
+    return `| \`${g.code}\` | ${g.level} | ${g.count} | ${g.firstSeen} | ${g.lastSeen} | ${g.sources.join(', ')} | ${preview} |`;
+  });
+  return [
+    '| Code | Level | Count | First seen | Last seen | Sources | Sample |',
+    '|------|-------|-------|------------|-----------|---------|--------|',
+    ...rows,
+  ].join('\n');
+}
+
+function formatCloudWatchStatus(logs) {
+  if (logs.cloudwatch?.error) {
+    return `⚠️ CloudWatch fetch failed: \`${logs.cloudwatch.error}\`. In-process buffer errors above are still reliable; Lambda runtime errors (timeouts, uncaught panics before onError) may be missing.`;
+  }
+  const groupCount = logs.cloudwatch?.logGroups?.length ?? 0;
+  return `CloudWatch lane queried ${groupCount} log group(s) successfully.`;
+}
 
 async function main() {
-  const [kpis, logs] = await Promise.all([collectKpis(), Promise.resolve(collectLogs())]);
+  const apiUrl = process.env.PLATO_API_URL;
+  if (!apiUrl) throw new Error('PLATO_API_URL is required');
+
+  const token = await login(apiUrl);
+  const [kpis, logs] = await Promise.all([collectKpis(apiUrl, token), collectLogs(apiUrl, token)]);
 
   const onTargetRate = kpis.totalCompletions
     ? ((kpis.withinTarget / kpis.totalCompletions) * 100).toFixed(1)
@@ -139,22 +97,18 @@ async function main() {
 | Avg exchanges (over-target) | ${kpis.avgExchangesOverTarget ?? 'N/A'} |
 | Active lessons | ${kpis.activeLessons} |
 
-## CloudWatch Errors (last 24h)
+## Errors by code (last ${logs.windowHours ?? 24}h)
 
-${formatErrors(logs)}
+Errors: ${logs.counts?.error ?? 0} · Warnings: ${logs.counts?.warn ?? 0} · Buffer: ${logs.buffer?.used ?? 0}/${logs.buffer?.size ?? 0}
 
-## CloudWatch Activity Summary
+${formatGroups(logs)}
 
-${logs.activity.length} log events across ${logs.logGroups.length} log groups in the last ${logs.windowHours}h.
-${logs.activity.length > 0 ? '\nSample:\n```json\n' + JSON.stringify(logs.activity.slice(0, 15), null, 2) + '\n```' : ''}
+## CloudWatch lane status
+
+${formatCloudWatchStatus(logs)}
 `;
 
   process.stdout.write(report);
-}
-
-function formatErrors(logs) {
-  if (logs.errors.length === 0) return 'No errors found.';
-  return '```json\n' + JSON.stringify(logs.errors.slice(0, 50), null, 2) + '\n```';
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

PR 2 of 2. Server endpoint shipped in #63 + #65 and is live in prod. This PR switches the pilot over to it and drops the GitHub Actions → AWS trust relationship entirely.

## Changes

- **`scripts/pilot-report.js`** — replaces the `execSync aws logs ...` calls with a single authenticated `fetch(/v1/admin/logs?view=groups)`. Throws on non-200 (fixes the silent-empty bug). Report renders a per-code table with counts, first/last seen, sources, and a sample message instead of a JSON dump of raw CloudWatch events. Adds an explicit "CloudWatch lane status" line so an AWS outage becomes a visible signal rather than missing rows.
- **`.github/workflows/pilot.yml`** — drops the `aws-actions/configure-aws-credentials` step, the `id-token: write` permission, and the `AWS_ROLE_ARN` secret reference. Updates the pilot prompt to triage by error code (e.g. `unhandled_error`, `ai_stream_error`) rather than raw log lines.

## Pilot prompt update

The agent now reads a compact table pre-grouped by code with counts, and the prompt points it at the highest-count code. The old "CloudWatch Errors (raw JSON)" section is gone.

## Test plan

- [ ] CI green (no server-side changes, so tests untouched — just syntax validity on scripts/pilot-report.js)
- [ ] After merge, manually dispatch plato-pilot via `gh workflow run pilot.yml`
- [ ] Confirm `/tmp/pilot-report.md` renders the new table and shows a successful CloudWatch lane status (now that prod has `logs:FilterLogEvents`)
- [ ] Sunday's scheduled cron run uses the new path
- [ ] After we're confident, delete the `AWS_ROLE_ARN` secret from the repo settings (manual step — not part of this PR)