### PR TITLE
Pilot test hotfixes: id-token + CloudWatch IAM

### DIFF
--- a/.github/workflows/pilot.yml
+++ b/.github/workflows/pilot.yml
@@ -12,6 +12,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write  # required by anthropics/claude-code-action@v1
     steps:
       - uses: actions/checkout@v4
         with:

--- a/server/template.yaml
+++ b/server/template.yaml
@@ -65,11 +65,17 @@ Resources:
                 - bedrock:InvokeModelWithResponseStream
               Resource: '*'
         - Statement:
+            # FilterLogEvents supports per-group resource scoping.
             - Effect: Allow
-              Action:
-                - logs:FilterLogEvents
-                - logs:DescribeLogGroups
+              Action: logs:FilterLogEvents
               Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/plato-${Stage}-*"
+            # DescribeLogGroups lists groups — AWS requires Resource: * for
+            # this action even when the caller only wants to see a subset.
+            # The caller applies a logGroupNamePrefix filter, so we only see
+            # plato log groups in practice.
+            - Effect: Allow
+              Action: logs:DescribeLogGroups
+              Resource: "*"
       Events:
         ApiCatchAll:
           Type: HttpApi
@@ -118,11 +124,17 @@ Resources:
                 - bedrock:InvokeModelWithResponseStream
               Resource: '*'
         - Statement:
+            # FilterLogEvents supports per-group resource scoping.
             - Effect: Allow
-              Action:
-                - logs:FilterLogEvents
-                - logs:DescribeLogGroups
+              Action: logs:FilterLogEvents
               Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/plato-${Stage}-*"
+            # DescribeLogGroups lists groups — AWS requires Resource: * for
+            # this action even when the caller only wants to see a subset.
+            # The caller applies a logGroupNamePrefix filter, so we only see
+            # plato log groups in practice.
+            - Effect: Allow
+              Action: logs:DescribeLogGroups
+              Resource: "*"
       FunctionUrlConfig:
         AuthType: NONE
         InvokeMode: RESPONSE_STREAM


### PR DESCRIPTION
Two hotfixes surfaced by the first pilot dispatch after #66 merged:

### 1. \`id-token: write\` restored on pilot workflow

Dropped in #66 thinking it was only for AWS, but \`anthropics/claude-code-action@v1\` needs it for its own OIDC flow. Dispatch failed with:

> Could not fetch an OIDC token. Did you remember to add 'id-token: write' to your workflow permissions?

Comment now explicitly says why it's required so future cleanup doesn't re-remove it.

### 2. CloudWatch IAM: \`logs:DescribeLogGroups\` needs \`Resource: *\`

The pilot report showed:

> User ... is not authorized to perform: \`logs:DescribeLogGroups\` on resource: \`arn:aws:logs:us-east-2:380610849750:log-group::log-stream:\`

\`DescribeLogGroups\` lists log groups and AWS only accepts \`Resource: "*"\` for that action. The scoped ARN in #63 covered \`FilterLogEvents\` but not \`Describe\`. Split the policy into two statements so \`FilterLogEvents\` stays tightly scoped to \`/aws/lambda/plato-\${Stage}-*\`.

## Test plan

- [ ] CI green
- [ ] After deploy: manually dispatch pilot, confirm pilot-report.md shows "CloudWatch lane queried N log group(s) successfully" instead of the IAM error, and the claude-code-action step runs (no OIDC error)