### PR TITLE
Fix CloudWatch log group prefix (end-to-end pilot test)

### DIFF
--- a/server/src/lib/cloudwatch-logs.js
+++ b/server/src/lib/cloudwatch-logs.js
@@ -14,8 +14,14 @@ function stage() {
   return process.env.STAGE || 'prod';
 }
 
-function logGroupPrefix() {
-  return `/aws/lambda/plato-${stage()}-`;
+// CloudFormation names the prod stack `plato` (not `plato-prod`) and the
+// playground stack `plato-playground`. Lambda then auto-creates log groups
+// of the form `/aws/lambda/<stack-name>-<LogicalId>-<hash>`. So the prefix
+// that matches both plato Lambdas in a stage is `/aws/lambda/<stack-name>-`.
+export function logGroupPrefix() {
+  const s = stage();
+  const stack = s === 'prod' ? 'plato' : `plato-${s}`;
+  return `/aws/lambda/${stack}-`;
 }
 
 function parseMessage(message) {

--- a/server/template.yaml
+++ b/server/template.yaml
@@ -68,7 +68,7 @@ Resources:
             # FilterLogEvents supports per-group resource scoping.
             - Effect: Allow
               Action: logs:FilterLogEvents
-              Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/plato-${Stage}-*"
+              Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${AWS::StackName}-*"
             # DescribeLogGroups lists groups — AWS requires Resource: * for
             # this action even when the caller only wants to see a subset.
             # The caller applies a logGroupNamePrefix filter, so we only see
@@ -127,7 +127,7 @@ Resources:
             # FilterLogEvents supports per-group resource scoping.
             - Effect: Allow
               Action: logs:FilterLogEvents
-              Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/plato-${Stage}-*"
+              Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${AWS::StackName}-*"
             # DescribeLogGroups lists groups — AWS requires Resource: * for
             # this action even when the caller only wants to see a subset.
             # The caller applies a logGroupNamePrefix filter, so we only see

--- a/server/tests/lib/cloudwatch-logs.test.js
+++ b/server/tests/lib/cloudwatch-logs.test.js
@@ -1,6 +1,6 @@
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { normalizeEvent } from '../../src/lib/cloudwatch-logs.js';
+import { normalizeEvent, logGroupPrefix } from '../../src/lib/cloudwatch-logs.js';
 
 describe('normalizeEvent', () => {
   it('preserves the logger-emitted logId so buffer + CloudWatch dedupe', () => {
@@ -42,5 +42,24 @@ describe('normalizeEvent', () => {
       const event = { eventId: 'x', timestamp: Date.now(), logStreamName: 's', message: msg };
       assert.equal(normalizeEvent(event, 'g'), null, `should drop: ${msg}`);
     }
+  });
+});
+
+describe('logGroupPrefix', () => {
+  let origStage;
+  beforeEach(() => { origStage = process.env.STAGE; });
+  afterEach(() => { if (origStage !== undefined) process.env.STAGE = origStage; else delete process.env.STAGE; });
+
+  it('matches the CloudFormation naming: prod stack is named "plato"', () => {
+    process.env.STAGE = 'prod';
+    // Actual Lambda log group is e.g. `/aws/lambda/plato-PlatoApiFunction-xIsSx1fu8kWd`.
+    // The old prefix `/aws/lambda/plato-prod-` would never match — CloudFormation
+    // gives the prod stack the bare name `plato`, not `plato-prod`.
+    assert.equal(logGroupPrefix(), '/aws/lambda/plato-');
+  });
+
+  it('includes the stage for non-prod stacks (playground → plato-playground)', () => {
+    process.env.STAGE = 'playground';
+    assert.equal(logGroupPrefix(), '/aws/lambda/plato-playground-');
   });
 });


### PR DESCRIPTION
Pilot test after #68 showed \`CloudWatch lane queried 0 log group(s) successfully\` — the IAM was fixed, but the prefix itself was wrong. CloudFormation names the prod stack \`plato\` (not \`plato-prod\`), so actual Lambda log groups are \`/aws/lambda/plato-PlatoApiFunction-*\`.

- \`cloudwatch-logs.js\`: map stage → stack name (\`prod\` → \`plato\`, else \`plato-<stage>\`). Matches template.yaml's own \`!If [IsProd, plato-users, plato-<Stage>-users]\` convention.
- \`template.yaml\`: IAM \`Resource\` now uses \`\${AWS::StackName}\` directly — can't get more correct than asking CloudFormation for its own name.
- Tests: 124 pass, includes new coverage for \`logGroupPrefix()\`.

## Test plan
- [ ] CI green
- [ ] After deploy, dispatch pilot again; confirm \`CloudWatch lane queried N log group(s) successfully\` with N > 0