### PR TITLE
Stop duplicate review posts — disable display_report

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -49,7 +49,11 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "claude"
-          display_report: true
+          # display_report intentionally disabled: it auto-posts an aggregated
+          # review from buffered inline annotations at end of session, which
+          # races with the explicit `gh pr review` call in the prompt and
+          # double-submits. See PR #73 (2026-04-17) where two reviews were
+          # posted 6s apart with slightly different bodies.
           claude_args: "--allowedTools Bash(*),Read(*),Glob,Grep --max-turns 20"
           prompt: |
             You are a skeptical code reviewer. Your job is to find real problems the author missed.


### PR DESCRIPTION
PR #73 received two reviews from \`claude[bot]\` 6 seconds apart with slightly different bodies. Only one code-review workflow fired, so it wasn't a duplicate run — the agent itself double-posted.

Root cause: \`display_report: true\` on \`anthropics/claude-code-action@v1\` auto-aggregates buffered inline annotations into a single review at end of session. Our prompt separately instructs the agent to run \`gh pr review --approve\` directly. Both paths fire in the same run.

Fix: remove \`display_report: true\`. The explicit \`gh pr review\` path in the prompt becomes the only review mechanism.

## Test plan

- [ ] Next PR gets exactly one review from \`claude[bot]\`
- [ ] If we ever want the inline-annotation UI back, switch the prompt to use the MCP review tools (\`mcp__github__create_pending_pull_request_review\` etc.) and re-enable \`display_report\`, but don't keep both paths active.