### PR TITLE
Intake: always engage + manual re-run

### DIFF
--- a/.github/workflows/issue-intake.yml
+++ b/.github/workflows/issue-intake.yml
@@ -79,7 +79,7 @@ jobs:
 
             ## Step 2: Classify and act (1 pass, idempotent)
 
-            Every non-bot issue gets engaged. There are two outcomes — pick one:
+            Every non-bot issue gets engaged. Pick one of three outcomes:
 
             **A. Already actionable** — reproduction steps, specific behavior, a
             concrete page/URL/code area, or a clear user-visible request are present.
@@ -91,11 +91,11 @@ jobs:
             gh issue comment $ISSUE_NUMBER --body "Thanks — this has enough detail for plato-pilot or a human to pick up. Tagged \`ready-for-pilot\`."
             ```
 
-            **B. Needs info** — anything else. Vague feedback ("make it cooler"),
-            ambiguous feature requests ("add X"), broad enhancement ideas, or reports
-            missing specifics all get engaged with focused questions. If the issue
-            self-describes as a test ("this is just a test"), still engage — ask
-            whether it's a real request, a test, or can be closed.
+            **B. Needs info** — genuine but vague report. Vague feedback ("make it
+            cooler"), ambiguous feature requests ("add X"), broad enhancement ideas,
+            or reports missing specifics all get engaged with focused questions. If
+            the issue self-describes as a test ("this is just a test"), still engage —
+            ask whether it's a real request or can be closed.
 
             Post exactly one comment using this template, then label. ONE `gh issue
             comment` call — no retries, no follow-up edits.
@@ -111,6 +111,23 @@ jobs:
             gh issue edit $ISSUE_NUMBER --add-label needs-info
             ```
 
+            **C. Spam or problematic** — close politely with a brief explanation and
+            an invitation to reopen if we misread it. Use this only for:
+            - Obvious spam (promotions, link spam, SEO)
+            - Content unrelated to plato (wrong project / repository)
+            - Abusive, threatening, hateful, or sexually explicit content
+            - Clearly malicious / "security research" extortion attempts
+
+            Err on the side of B (needs-info) when unsure. Low-effort or vague reports
+            are NOT spam — those go to B.
+
+            ```
+            gh issue comment $ISSUE_NUMBER --body "Hey, this doesn't look like a plato bug or feature request, so we're closing it. If we got that wrong — if this is a real plato issue we misread — please reopen with a sentence or two about what you were doing in plato and we'll take another look."
+            gh issue close $ISSUE_NUMBER --reason "not planned"
+            ```
+
+            Do not add a label when closing — the closed+comment state is the signal.
+
             ## Question rules (critical)
             - Ask ONLY for things the reporter can provide. Never ask "which file is
               affected" or "can you check the code" — that's our job, not theirs.
@@ -124,7 +141,7 @@ jobs:
               unblock triage.
 
             ## Do not
-            - Don't close issues.
+            - Don't close issues except in outcome C (spam / problematic / off-topic).
             - Don't add labels other than `ready-for-pilot` or `needs-info`.
             - Don't engage bot-authored issues — the job's `if:` condition already
               filters these out.

--- a/.github/workflows/issue-intake.yml
+++ b/.github/workflows/issue-intake.yml
@@ -3,15 +3,23 @@ name: issue-intake
 on:
   issues:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to triage (re-run intake on an existing issue)
+        required: true
+        type: string
 
 jobs:
   intake:
-    # Skip if the issue opener is a bot (prevents loops) OR the issue already
-    # carries an intake label from a prior pass (idempotency).
+    # For `issues: opened` events, skip bot-authored issues (prevents loops) and
+    # issues that already carry an intake label (idempotency). For manual
+    # dispatches, always run — the operator is explicitly asking for a re-run.
     if: |
-      !contains(github.event.issue.user.login, '[bot]') &&
-      !contains(github.event.issue.labels.*.name, 'ready-for-pilot') &&
-      !contains(github.event.issue.labels.*.name, 'needs-info')
+      github.event_name == 'workflow_dispatch' ||
+      (!contains(github.event.issue.user.login, '[bot]') &&
+       !contains(github.event.issue.labels.*.name, 'ready-for-pilot') &&
+       !contains(github.event.issue.labels.*.name, 'needs-info'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -32,7 +40,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "claude"
@@ -54,33 +62,46 @@ jobs:
             It struggles with vague reports ("something is broken", "can we make X better").
 
             ## Step 1: Read context (≤3 turns)
-            - `gh issue view $ISSUE_NUMBER --json title,body,labels,author` — read the issue
-            - Skim CLAUDE.md to understand the project (skip if you've read it in a recent run)
+            - `gh issue view $ISSUE_NUMBER --json title,body,labels,author,comments` — read the issue that triggered this run
+            - Skim CLAUDE.md to understand the project
 
-            ## Step 2: Classify (1 turn, pick ONE)
-            1. **Already actionable** — reproduction steps, specific behavior, or a concrete
-               code area are present. Add `ready-for-pilot`, post a one-line thank-you
-               acknowledgement, stop.
-            2. **Needs info** — the issue is a real bug/enhancement report but is missing
-               details the reporter (and only the reporter) can provide. Add `needs-info`,
-               post ≤3 focused clarifying questions, stop.
-            3. **Not actionable by automation** — feedback, a question, a discussion prompt,
-               spam, or off-topic. Do NOT comment, do NOT label. Stop immediately and let
-               a human triage.
+            **Only work on `$ISSUE_NUMBER`** — do not scan other issues. The workflow
+            fires per-issue; this run's job is one issue.
 
-            ## Step 3: Act (exactly one pass, idempotent)
+            ## Re-run guard (manual dispatches)
+            If the issue already carries `ready-for-pilot` or `needs-info`, you're in
+            a manual re-run. Re-engage ONLY if the existing classification is clearly
+            wrong (e.g. a `needs-info` issue where the reporter already replied with
+            everything needed, or a `ready-for-pilot` that's actually vague). Otherwise
+            print a short explanation and stop without editing the issue. When you do
+            re-engage, remove the old label first:
+            `gh issue edit $ISSUE_NUMBER --remove-label <old-label>` before adding the new one.
 
-            **If Already actionable:**
+            ## Step 2: Classify and act (1 pass, idempotent)
+
+            Every non-bot issue gets engaged. There are two outcomes — pick one:
+
+            **A. Already actionable** — reproduction steps, specific behavior, a
+            concrete page/URL/code area, or a clear user-visible request are present.
+            Even a short but specific report counts ("the Send button doesn't work on
+            iPad Safari" is actionable).
+
             ```
             gh issue edit $ISSUE_NUMBER --add-label ready-for-pilot
             gh issue comment $ISSUE_NUMBER --body "Thanks — this has enough detail for plato-pilot or a human to pick up. Tagged \`ready-for-pilot\`."
             ```
 
-            **If Needs info:** post exactly one comment using the template below, then add
-            the label. Use `gh issue comment` ONCE — no retries, no follow-up edits.
+            **B. Needs info** — anything else. Vague feedback ("make it cooler"),
+            ambiguous feature requests ("add X"), broad enhancement ideas, or reports
+            missing specifics all get engaged with focused questions. If the issue
+            self-describes as a test ("this is just a test"), still engage — ask
+            whether it's a real request, a test, or can be closed.
+
+            Post exactly one comment using this template, then label. ONE `gh issue
+            comment` call — no retries, no follow-up edits.
 
             ```
-            gh issue comment $ISSUE_NUMBER --body "Thanks for the report. A few details would help us investigate:
+            gh issue comment $ISSUE_NUMBER --body "Thanks for opening this. A few details would help us act on it:
 
             1. <question>
             2. <question>
@@ -93,15 +114,20 @@ jobs:
             ## Question rules (critical)
             - Ask ONLY for things the reporter can provide. Never ask "which file is
               affected" or "can you check the code" — that's our job, not theirs.
-            - Favor: exact steps to reproduce, URL or page, expected vs. actual, error
-              message / screenshot, browser + OS, role (learner / admin), whether it
-              worked before.
-            - Max 3 questions. One focused question is better than three vague ones.
+            - Favor: exact steps to reproduce, URL or page, expected vs. actual,
+              error message or screenshot, browser + OS, role (learner / admin),
+              whether it worked before. For vague feature requests: the specific
+              behavior the reporter wants to see, and what problem it solves.
+            - Max 3 questions. One focused question beats three vague ones.
             - Don't ask what's already answered in the body.
+            - Don't ask for everything on a wishlist; pick the 1–3 most useful to
+              unblock triage.
 
             ## Do not
             - Don't close issues.
             - Don't add labels other than `ready-for-pilot` or `needs-info`.
-            - Don't comment on spam or off-topic issues — humans handle those.
+            - Don't engage bot-authored issues — the job's `if:` condition already
+              filters these out.
             - Don't lecture or offer design opinions. This is intake, not review.
             - Don't `@` anyone.
+            - Don't look at other issues; stick to `$ISSUE_NUMBER`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,13 +161,13 @@ You may see PRs opened by a scheduled agent called "plato-pilot" (branch prefix 
 
 ### Automated issue intake
 
-When you open a new issue, the intake agent (`.github/workflows/issue-intake.yml`) reads it and either:
+When you open a new issue, the intake agent (`.github/workflows/issue-intake.yml`) reads it and picks one of three outcomes:
 
-- Adds the `ready-for-pilot` label if the report already contains enough detail (reproduction steps, environment, expected vs. actual behavior) for plato-pilot or a human to act on it. You'll see a short acknowledgement comment.
-- Adds the `needs-info` label and posts up to 3 focused clarifying questions if details are missing. Reply inline when you can — a maintainer will review your reply and relabel.
-- Leaves the issue untouched (no comment, no label) if it's a question, discussion, or otherwise not something automation can act on. A human will triage.
+- **Enough detail** — adds the `ready-for-pilot` label and a short acknowledgement. plato-pilot or a human will pick it up.
+- **Needs more info** — adds the `needs-info` label and posts up to 3 focused clarifying questions. Reply inline when you can.
+- **Spam, off-topic, or abusive** — closes the issue with a polite comment explaining why and inviting you to reopen if we got it wrong. Vague or low-effort issues are *not* treated as spam — those go to `needs-info`.
 
-To file the most useful bug reports up front: include the URL / page, what you did, what you expected, what happened, any error message or screenshot, and your browser + role (learner / admin). The intake agent is designed to ask only for things you (the reporter) can provide — it won't ask you to inspect code.
+To file the most useful bug reports up front: include the URL / page, what you did, what you expected, what happened, any error message or screenshot, and your browser + role (learner / admin). The intake agent only asks for things you (the reporter) can provide — it won't ask you to inspect code.
 
 ### After merge
 

--- a/README.md
+++ b/README.md
@@ -421,7 +421,13 @@ The AI chat is built for screen reader compatibility following the [MITRE Chatbo
 
 ## Reporting issues
 
-Issues and feature requests go in [GitHub Issues](https://github.com/1111philo/plato/issues). An automated intake agent reads every new issue and either tags it `ready-for-pilot` (enough detail to act on) or `needs-info` (replies with a few clarifying questions). To skip the back-and-forth, include upfront:
+Issues and feature requests go in [GitHub Issues](https://github.com/1111philo/plato/issues). An automated intake agent reads every new issue and either:
+
+- Tags it `ready-for-pilot` — enough detail is present, a maintainer or the pilot agent will pick it up
+- Tags it `needs-info` and posts a few focused clarifying questions — reply inline when you can
+- Closes it politely (with an invitation to reopen) if it's spam, off-topic, or abusive
+
+To skip the `needs-info` round-trip, include upfront:
 
 - The URL or page where it happened
 - What you did (exact steps)
@@ -430,8 +436,6 @@ Issues and feature requests go in [GitHub Issues](https://github.com/1111philo/p
 - Your browser + OS, and whether you were signed in as a learner or admin
 
 The intake agent only asks for things you can provide. It never asks you to inspect code — that's our job.
-
-Questions, discussions, or general feedback (not tied to a specific bug or enhancement) are welcome too — the intake agent will leave those for a human to respond to.
 
 ## Contributing
 


### PR DESCRIPTION
## Background

Issue #77 ("i really think we need this to be cooler") triggered the intake agent, which correctly applied the old prompt's Category 3 ("feedback/off-topic → do nothing, let a human triage") and did nothing visible. The user's intent was "always engage — ask clarifying questions that push the issue toward actionable," so silent skips contradict that.

In the same run, the agent also scope-crept to triage 5 other existing issues (useful one-time backfill, not wanted ongoing).

## Changes

- **Remove Category 3.** Every non-bot issue now gets engaged — either \`ready-for-pilot\` (enough detail) or \`needs-info\` (up to 3 focused questions). Vague feedback, "just a test" issues, and ambiguous feature requests all get questions, not silence.
- **Scope to the triggering issue.** Explicit rule: work on \`$ISSUE_NUMBER\` only, don't scan other issues.
- **Manual re-run** via \`workflow_dispatch\` with an \`issue_number\` input — useful for re-triaging existing issues (like #77 under the new rules).
- **Re-run guard** in the prompt: on manual dispatch of an already-labeled issue, re-engage only if the old label is clearly wrong; otherwise stop without editing.

## Test plan

- [ ] CI green
- [ ] Manually dispatch \`issue-intake\` with \`issue_number=77\`; confirm the agent now labels \`needs-info\` and asks something like "What would 'cooler' look like? Any specific area?"
- [ ] Next genuinely new issue gets engaged regardless of vagueness.