### PR TITLE
Slim README; extract deploy guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Project-level instructions for Claude Code sessions working on plato.
 
 ## Project overview
 
-plato is an open-source, AI-powered [microlearning](https://philosophers.group/platos-microlearning/) platform. Learners work through focused lessons in a continuous conversation with an AI coach, designed for completion in ~20 minutes.
+plato is an Open Source, AI-powered [microlearning](https://philosophers.group/platos-microlearning/) platform. Learners work through focused lessons in a continuous conversation with an AI coach, designed for completion in ~20 minutes.
 
 - `client/` — React 19 + Vite SPA
 - `server/` — Node.js + Hono, deployed as AWS Lambda (SAM)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # plato
 
-An open-source, AI-powered [microlearning](https://philosophers.group/platos-microlearning/) platform. Learners work through focused, exemplar-driven lessons in a continuous conversation with an AI coach that creates activities, evaluates submissions, and tracks progress toward mastery — all in under 20 minutes.
+An Open Source, AI-powered [microlearning](https://philosophers.group/platos-microlearning/) platform. Learners work through focused, exemplar-driven lessons in a continuous conversation with an AI coach that creates activities, evaluates submissions, and tracks progress toward mastery — all in under 20 minutes.
 
 Built by [11:11 Philosopher's Group](https://github.com/1111philo).
 
@@ -31,14 +31,23 @@ The admin dashboard tracks an **On-Target Rate** KPI showing what percentage of 
 
 Admins manage everything from `/plato`: lessons, users, a classroom customizer (styles + knowledge base), and integrations.
 
-## Repository structure
+## Reporting issues
 
-```
-plato/
-  client/       React 18 + Vite SPA (the learner and admin UI)
-  server/       Node.js + Hono + AWS Lambda + DynamoDB (API, auth, data, AI proxy)
-  scripts/      Build and deploy tooling
-```
+Issues and feature requests go in [GitHub Issues](https://github.com/1111philo/plato/issues). An automated intake agent reads every new issue and either:
+
+- Tags it `ready-for-pilot` — enough detail is present, a maintainer or the pilot agent will pick it up
+- Tags it `needs-info` and posts a few focused clarifying questions — reply inline when you can
+- Closes it politely (with an invitation to reopen) if it's spam, off-topic, or abusive
+
+To skip the `needs-info` round-trip, include upfront:
+
+- The URL or page where it happened
+- What you did (exact steps)
+- What you expected vs. what actually happened
+- Any error message, screenshot, or browser console output
+- Your browser + OS, and whether you were signed in as a learner or admin
+
+The intake agent only asks for things you can provide. It never asks you to inspect code — that's our job.
 
 ## Quick start
 
@@ -81,370 +90,36 @@ plato needs access to Claude models. Set one of these:
 | **Anthropic API** (recommended) | `ANTHROPIC_API_KEY=sk-ant-...` | Local dev, small deployments |
 | **Amazon Bedrock** | AWS credentials + `AI_PROVIDER=bedrock` | Production on AWS |
 
-The Anthropic API key is the easiest way to get started. Get one at [console.anthropic.com](https://console.anthropic.com/settings/keys).
-
-If `ANTHROPIC_API_KEY` is set, plato uses it automatically. For Bedrock, set `AI_PROVIDER=bedrock` and configure AWS credentials.
+Get an Anthropic API key at [console.anthropic.com](https://console.anthropic.com/settings/keys). If `ANTHROPIC_API_KEY` is set, plato uses it automatically. For Bedrock, set `AI_PROVIDER=bedrock` and configure AWS credentials.
 
 Then log in and navigate to `/plato` to see the admin dashboard, or `/lessons` to start learning.
 
-### Development workflow
+## Project layout
 
-For client changes with hot reload:
-
-```bash
-cd client && npm run dev    # Vite dev server on :5173
+```
+plato/
+  client/    React 19 + Vite SPA (learner and admin UI)
+  server/    Node.js + Hono + AWS Lambda + DynamoDB (API, auth, data, AI proxy)
+  scripts/   Build and deploy tooling
+  docs/      Extended guides (deployment, etc.)
 ```
 
-For server changes (restart required):
+For architectural details (AI agents, data model, auth, conventions) see [CLAUDE.md](CLAUDE.md).
 
-```bash
-cd server && node dev-sqlite.js    # API server on :3000
-```
+## Deployment
 
-When developing the client with Vite's dev server, API calls go to `localhost:3000` — configure your browser or use a proxy.
-
-> **AI features** require the server to proxy to Amazon Bedrock. Without it, the app is fully navigable but lesson conversations won't work.
-
-## Architecture
-
-### Overview
-
-- **Login required** — all data is server-side, no browser storage beyond auth tokens
-- **8 AI agents** via Amazon Bedrock: coach, lesson-owner, lesson-creator, lesson-extractor, knowledge-base-editor, knowledge-base-extractor, learner-profile-owner, learner-profile-update
-- **Admin dashboard** at `/plato` — manage lessons, users, classroom customizer (styles + knowledge base), and integrations
-- **Single-tenant** — one instance per deployment, global settings, multiple admins
-
-### Client
-
-React SPA built with Vite. Key areas:
-
-| Directory | Purpose |
-|-----------|---------|
-| `src/pages/` | Route-level components (lessons, settings, login, admin) |
-| `src/components/` | Shared UI (AppShell, chat, modals) |
-| `src/contexts/` | React contexts (auth, app state, modals) |
-| `src/lib/` | Engines (lesson loop, lesson creation, profile queue, sync) |
-| `js/` | Service modules (storage, orchestrator, auth, API, lesson parsing, validators) |
-
-Admin pages under `src/pages/admin/` are lazy-loaded and role-gated.
-
-### Server
-
-Hono framework on AWS Lambda with DynamoDB (or SQLite for local dev). Two Lambda functions handle requests:
-
-- **API Gateway** — buffered responses for CRUD operations
-- **Function URL** — streaming SSE for AI chat responses
-
-**DynamoDB tables:** users, invites, refresh-tokens, sync-data, audit-log
-
-All content (system prompts, lessons, knowledge base, theme/branding, classroom identity) is stored in the sync-data table under a `_system` user — no additional tables needed.
-
-**Auth:** JWT access tokens (15 min) + refresh tokens (30 day, rotated). Invite-based registration. First-time setup creates the initial admin via a UI flow.
-
-### AI agents
-
-| Agent | Role |
-|-------|------|
-| **Coach** | Learner's companion in one continuous conversation — coaches, creates activities, evaluates submissions, tracks progress |
-| **Lesson Owner** | Initializes a lesson knowledge base from the lesson prompt + learner profile |
-| **Lesson Creator** | Guides admins through designing lessons via conversation |
-| **Lesson Extractor** | Extracts lesson markdown from a creation conversation |
-| **Knowledge Base Editor** | Helps admins create and edit the program knowledge base via conversation |
-| **Knowledge Base Extractor** | Merges existing KB with conversation changes to produce updated markdown |
-| **Learner Profile Owner** | Deep profile update on lesson completion |
-| **Learner Profile Update** | Incremental profile update from feedback/observations |
-
-System prompts are bundled in `client/prompts/` and upserted to the database on every server startup. Admins cannot edit prompts directly — prompt changes are deployed through code updates.
-
-## Deploying to AWS
-
-### Prerequisites
-
-- AWS SAM CLI
-- An AWS account with permissions for Lambda, DynamoDB, API Gateway, IAM, S3, and SES
-- A verified SES sender email/domain
-- An Anthropic API key or Amazon Bedrock access
-
-### 1. SSM parameters
-
-Create these in AWS Systems Manager Parameter Store before deploying. Replace `{stage}` with your stage name (e.g., `prod`, `playground`):
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `/plato/{stage}/jwt-secret` | SecureString | JWT signing secret |
-| `/plato/{stage}/ses-from-email` | String | Verified SES sender email |
-| `/plato/{stage}/app-url` | String | Public URL (for invite/reset links) |
-| `/plato/{stage}/admin-email` | String | Bootstrap admin email (optional — setup UI handles this) |
-| `/plato/{stage}/admin-password` | SecureString | Bootstrap admin password (optional) |
-
-### 2. Configure SAM
-
-Copy the example config and customize it for your AWS account:
-
-```bash
-cd server
-cp samconfig.toml.example samconfig.toml
-# Edit samconfig.toml — set your region, stack name, and AWS profile
-```
-
-`samconfig.toml` is gitignored so your local config stays out of version control.
-
-### 3. Deploy manually
-
-```bash
-# Build client
-cd client && npm ci && npm run build && cd ..
-
-# Build server
-cd server && sam build
-
-# Bundle client SPA into Lambda artifacts
-cp -r ../client/dist .aws-sam/build/PlatoStreamFunction/client-dist
-cp -r ../client/dist .aws-sam/build/PlatoApiFunction/client-dist
-
-# Bundle content source files (prompts, lessons) for seeding
-mkdir -p .aws-sam/build/PlatoApiFunction/client-content .aws-sam/build/PlatoStreamFunction/client-content
-cp -r ../client/prompts ../client/data .aws-sam/build/PlatoApiFunction/client-content/
-cp -r ../client/prompts ../client/data .aws-sam/build/PlatoStreamFunction/client-content/
-
-# Generate version.json from the latest Beta-RC-* tag
-VERSION=$(git describe --tags --abbrev=0 --match='Beta-RC-*' 2>/dev/null || echo 'Beta-RC-0')
-echo "{\"version\":\"${VERSION}\"}" > .aws-sam/build/PlatoApiFunction/version.json
-cp .aws-sam/build/PlatoApiFunction/version.json .aws-sam/build/PlatoStreamFunction/version.json
-
-# Deploy (default stage is prod)
-sam deploy
-# Or deploy a specific stage
-sam deploy --parameter-overrides Stage=playground --stack-name plato-playground
-```
-
-The `Stage` parameter controls DynamoDB table name prefixes and SSM parameter paths. See `server/template.yaml` for the full infrastructure definition.
-
-### 4. Set up CI/CD (recommended)
-
-For production deployments, we recommend automating deploys from a **private fork** via GitHub Actions. This keeps your AWS credentials and deploy config out of the public repo. The flow here uses `repository_dispatch`: pushing to the public repo fires a dispatch event to the private fork, which runs the actual deploy. No manual pushing to the deploy remote, and the deploy workflows never need to exist in the public repo.
-
-**Create a private fork:**
-
-```bash
-gh repo fork 1111philo/plato --fork-name my-plato --org my-org --clone=false
-gh repo edit my-org/my-plato --visibility private --accept-visibility-change-consequences
-```
-
-**Set up OIDC authentication** (no static AWS keys needed):
-
-1. Ensure your AWS account has a GitHub OIDC provider (one-time setup):
-   ```bash
-   aws iam create-open-id-connect-provider \
-     --url https://token.actions.githubusercontent.com \
-     --client-id-list sts.amazonaws.com \
-     --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1
-   ```
-
-2. Create an IAM role that GitHub Actions can assume. The trust policy should allow your private fork repo:
-   ```json
-   {
-     "Version": "2012-10-17",
-     "Statement": [{
-       "Effect": "Allow",
-       "Principal": {
-         "Federated": "arn:aws:iam::YOUR_ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
-       },
-       "Action": "sts:AssumeRoleWithWebIdentity",
-       "Condition": {
-         "StringEquals": { "token.actions.githubusercontent.com:aud": "sts.amazonaws.com" },
-         "StringLike": { "token.actions.githubusercontent.com:sub": "repo:my-org/my-plato:*" }
-       }
-     }]
-   }
-   ```
-
-3. Attach a permissions policy to the role with access to CloudFormation, Lambda, S3, API Gateway, DynamoDB, IAM (for role creation), and SSM (parameter reads).
-
-**Create a dispatch token:** In GitHub, generate a fine-grained personal access token with `contents:write` permission scoped to your private fork. Add it to the **public repo** as a secret named `DEPLOY_DISPATCH_TOKEN`. The public repo's trigger workflow uses this token to fire dispatch events at the private fork.
-
-**The trigger workflow** lives in the public repo at `.github/workflows/trigger-deploy.yml` (already included in this project). On push to `main` or `playground`, it fires a `deploy-prod` or `deploy-playground` `repository_dispatch` event at the private fork with the commit SHA as payload.
-
-**Add a deploy workflow** to your private fork at `.github/workflows/deploy.yml`:
-
-```yaml
-name: Deploy to AWS
-
-on:
-  repository_dispatch:
-    types: [deploy-prod]
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Ref on the public repo to deploy (branch / tag / SHA)'
-        required: false
-        default: 'main'
-
-env:
-  SOURCE_REPO: my-org/my-plato-source  # your public repo
-  SOURCE_REF: ${{ github.event.client_payload.sha || inputs.ref || 'main' }}
-
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ env.SOURCE_REPO }}
-          ref: ${{ env.SOURCE_REF }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - run: cd server && npm ci && npm test
-
-  deploy:
-    needs: test
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ env.SOURCE_REPO }}
-          ref: ${{ env.SOURCE_REF }}
-          fetch-depth: 0  # need history + tags so we can read the latest Beta-RC-* tag
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - uses: aws-actions/setup-sam@v2
-        with:
-          use-installer: true
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::YOUR_ACCOUNT_ID:role/YOUR_DEPLOY_ROLE
-          aws-region: YOUR_REGION
-      - run: cd client && npm ci && npm run build
-      - run: cd server && sam build
-      - run: |
-          cp -r client/dist server/.aws-sam/build/PlatoApiFunction/client-dist
-          cp -r client/dist server/.aws-sam/build/PlatoStreamFunction/client-dist
-      - run: |
-          mkdir -p server/.aws-sam/build/PlatoApiFunction/client-content server/.aws-sam/build/PlatoStreamFunction/client-content
-          cp -r client/prompts client/data server/.aws-sam/build/PlatoApiFunction/client-content/
-          cp -r client/prompts client/data server/.aws-sam/build/PlatoStreamFunction/client-content/
-      - name: Generate version.json from latest tag
-        run: |
-          VERSION=$(git describe --tags --abbrev=0 --match='Beta-RC-*' 2>/dev/null || echo 'Beta-RC-0')
-          echo "{\"version\":\"${VERSION}\"}" > server/.aws-sam/build/PlatoApiFunction/version.json
-          cp server/.aws-sam/build/PlatoApiFunction/version.json server/.aws-sam/build/PlatoStreamFunction/version.json
-      - run: >
-          cd server && sam deploy
-          --config-env ci
-          --stack-name plato
-          --region YOUR_REGION
-          --s3-bucket YOUR_SAM_S3_BUCKET
-          --s3-prefix plato
-          --capabilities CAPABILITY_IAM
-          --no-confirm-changeset
-          --no-fail-on-empty-changeset
-          --parameter-overrides Stage=prod
-```
-
-Replace `YOUR_ACCOUNT_ID`, `YOUR_DEPLOY_ROLE`, `YOUR_REGION`, `YOUR_SAM_S3_BUCKET`, and `SOURCE_REPO` with your values. The S3 bucket is the one SAM creates on first manual deploy (named `aws-sam-cli-managed-default-samclisourcebucket-*`).
-
-**Pre-deploy backups:** Add a step before `sam deploy` to back up your DynamoDB tables. For example, loop over your table names and call `aws dynamodb create-backup` for each, then prune old backups (keeping the last 5 per table).
-
-**Multiple environments:** For a staging environment (e.g., `playground`), add a second workflow to the private fork that listens on `repository_dispatch` type `deploy-playground` and deploys with `--stack-name plato-playground --parameter-overrides Stage=playground`. Each stage gets its own DynamoDB tables and SSM parameters. The trigger workflow in the public repo already fires `deploy-playground` on push to the `playground` branch.
-
-**Workflow:** Push or merge to the public repo's `main` or `playground` — the trigger workflow fires the dispatch, the private fork's deploy workflow picks it up, checks out the public repo at that SHA, runs tests, and deploys. Tests run first — deploy only happens if they pass. For re-deploying a specific SHA manually, use `workflow_dispatch` on the private fork's deploy workflow with an optional `ref` input.
-
-### Custom domain (optional)
-
-To serve the app from a custom domain:
-
-1. Create a CloudFront distribution with the Lambda Function URL as a **Custom Origin** (HTTPS-only)
-2. Set the Origin Request Policy to **AllViewerExceptHostHeader** (required for Lambda Function URLs)
-3. Set the Cache Policy to **CachingDisabled** (the Lambda handles caching headers)
-4. Add your domain as a CloudFront alternate domain name and attach an ACM certificate (must be in us-east-1)
-5. Point your DNS (CNAME or alias) to the CloudFront distribution domain
-
-### Backups
-
-Production DynamoDB tables are protected by two backup layers:
-
-- **Point-in-Time Recovery (PITR)** — enabled on all 5 prod tables, allowing restore to any second in the last 35 days. Handles accidental deletes, data corruption, or bugs discovered after the fact.
-- **Pre-deploy snapshots** — the CI/CD deploy workflow automatically creates on-demand backups of all prod tables before each deploy. Old backups are pruned to keep the last 5 per table. These provide named restore points tied to specific deploys.
-
-To restore from a pre-deploy snapshot, use the AWS Console (DynamoDB > Backups) or the CLI:
-
-```bash
-aws dynamodb restore-table-from-backup \
-  --target-table-name plato-users-restored \
-  --backup-arn arn:aws:dynamodb:us-east-2:ACCOUNT:table/plato-users/backup/BACKUP_ID
-```
-
-To restore from PITR:
-
-```bash
-aws dynamodb restore-table-to-point-in-time \
-  --source-table-name plato-users \
-  --target-table-name plato-users-restored \
-  --restore-date-time 2026-04-01T12:00:00Z
-```
-
-In both cases, DynamoDB restores to a new table — rename or swap as needed.
-
-## Versioning
-
-plato uses a `Beta-RC-X` version scheme tracked via git tags. On each push to `main` (typically from a merged PR), `.github/workflows/version-bump.yml` creates the next `Beta-RC-N` tag and a matching GitHub release. No version file is tracked in git — `version.json` is generated at deploy time from the latest tag and included in the Lambda bundle. The current version is displayed in the admin sidebar with a link to the GitHub repo.
-
-The `main` branch is protected — all changes require a pull request.
-
+For production deployment to AWS — SAM setup, CI/CD from a private fork, custom domains, backups — see **[docs/DEPLOY.md](docs/DEPLOY.md)**.
 
 ## Accessibility
 
-plato is designed to be fully accessible with screen readers (VoiceOver, NVDA, JAWS) and keyboard-only navigation.
-
-- All interactive elements have accessible names and are keyboard-operable
-- Route changes are announced via a global `ScreenReaderAnnounce` component
-- Skip-to-content link on every page
-
-### Chat interface
-
-The AI chat is built for screen reader compatibility following the [MITRE Chatbot Accessibility Playbook](https://mitre.github.io/chatbot-accessibility-playbook/) and [Orange accessibility guidelines](https://a11y-guidelines.orange.com/en/articles/chatbot/):
-
-- **Silent by default** — the chat log uses `role="log"` with `aria-live="off"` and `aria-label="Chat log"` so VoiceOver never reads messages unprompted
-- **Controlled announcements** — a separate `role="status"` live region announces "New message from coach" only when a complete response arrives, then auto-clears after ~3s so the text doesn't linger as navigable DOM content
-- **Streaming content hidden** — in-progress AI responses are `aria-hidden` to prevent screen readers from reading partial text
-- **Sender identification** — each message includes a screen-reader-only prefix ("Coach says:" / "You said:") that reads inline as part of the message content, so messages aren't burdened with duplicate aria labels
-- **Keyboard navigation** — `Alt+ArrowUp` / `Alt+ArrowDown` to jump between messages in the chat log
-- **Send shortcut** — `Cmd+Return` (macOS) or `Ctrl+Enter` (Windows/Linux) sends a message; plain `Enter` inserts a newline
-- **Dialog focus** — modal dialogs (e.g., lesson Objectives) move focus to their title on open so the dialog's purpose is announced first
-- **Focus management** — when focus is in the chat log, new messages receive focus automatically; when focus is elsewhere, only the status announcement fires
-- **Tab notification** — document title flashes "(New message)" when the browser tab is in the background
-
-## Reporting issues
-
-Issues and feature requests go in [GitHub Issues](https://github.com/1111philo/plato/issues). An automated intake agent reads every new issue and either:
-
-- Tags it `ready-for-pilot` — enough detail is present, a maintainer or the pilot agent will pick it up
-- Tags it `needs-info` and posts a few focused clarifying questions — reply inline when you can
-- Closes it politely (with an invitation to reopen) if it's spam, off-topic, or abusive
-
-To skip the `needs-info` round-trip, include upfront:
-
-- The URL or page where it happened
-- What you did (exact steps)
-- What you expected vs. what actually happened
-- Any error message, screenshot, or browser console output
-- Your browser + OS, and whether you were signed in as a learner or admin
-
-The intake agent only asks for things you can provide. It never asks you to inspect code — that's our job.
+plato is designed to be fully usable with screen readers (VoiceOver, NVDA, JAWS) and keyboard-only navigation. The AI chat follows the [MITRE Chatbot Accessibility Playbook](https://mitre.github.io/chatbot-accessibility-playbook/) and [Orange accessibility guidelines](https://a11y-guidelines.orange.com/en/articles/chatbot/): silent-by-default chat log, controlled announcements for new messages, keyboard navigation between messages (`Alt+ArrowUp`/`Alt+ArrowDown`), and `Cmd/Ctrl+Enter` to send. Implementation details live in [CLAUDE.md](CLAUDE.md).
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, guidelines, and how to submit changes.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, conventions, and how to submit changes. The `main` branch is protected — all changes require a pull request.
 
 ## License
 
 Copyright (C) 2026 [11:11 Philosopher's Group](https://github.com/1111philo)
 
-This program is free software: you can redistribute it and/or modify it under the terms of the [GNU Affero General Public License v3.0](LICENSE) as published by the Free Software Foundation.
-
-This means you're free to use, modify, and distribute this software, but any modified version that's accessible over a network must also be made available under the same license. See the [LICENSE](LICENSE) file for details.
+This program is free software: you can redistribute it and/or modify it under the terms of the [GNU Affero General Public License v3.0](LICENSE) as published by the Free Software Foundation. Modified versions that are accessible over a network must also be made available under the same license.

--- a/client/prompts/knowledge-base-editor.md
+++ b/client/prompts/knowledge-base-editor.md
@@ -13,7 +13,7 @@ You help admins create and maintain the program knowledge base — a markdown do
 
 ## How plato works
 
-plato is an open-source microlearning platform where learners work through focused lessons in a continuous conversation with an AI coach. Each lesson is designed for completion in ~20 minutes (~11 coaching exchanges). Here's how the system fits together:
+plato is an Open Source microlearning platform where learners work through focused lessons in a continuous conversation with an AI coach. Each lesson is designed for completion in ~20 minutes (~11 coaching exchanges). Here's how the system fits together:
 
 **The learner experience:**
 1. A learner picks a lesson from their lesson list.

--- a/client/prompts/lesson-creator.md
+++ b/client/prompts/lesson-creator.md
@@ -14,7 +14,7 @@ You help admins design well-structured lessons. Your job is to coach them throug
 
 ## How plato works
 
-plato is an open-source microlearning platform where learners work through focused lessons in a continuous conversation with an AI coach. Here's how the system fits together:
+plato is an Open Source microlearning platform where learners work through focused lessons in a continuous conversation with an AI coach. Here's how the system fits together:
 
 **The learner experience:**
 1. A learner picks a lesson from their lesson list.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,237 @@
+# Deploying plato to AWS
+
+This guide covers production deployment to AWS via SAM, optional CI/CD from a private fork, custom domain setup, and backup procedures.
+
+For a quick local development setup, see the [main README](../README.md#quick-start).
+
+## Prerequisites
+
+- AWS SAM CLI
+- An AWS account with permissions for Lambda, DynamoDB, API Gateway, IAM, S3, and SES
+- A verified SES sender email/domain
+- An Anthropic API key or Amazon Bedrock access
+
+## 1. SSM parameters
+
+Create these in AWS Systems Manager Parameter Store before deploying. Replace `{stage}` with your stage name (e.g., `prod`, `playground`):
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `/plato/{stage}/jwt-secret` | SecureString | JWT signing secret |
+| `/plato/{stage}/ses-from-email` | String | Verified SES sender email |
+| `/plato/{stage}/app-url` | String | Public URL (for invite/reset links) |
+| `/plato/{stage}/admin-email` | String | Bootstrap admin email (optional — setup UI handles this) |
+| `/plato/{stage}/admin-password` | SecureString | Bootstrap admin password (optional) |
+
+## 2. Configure SAM
+
+Copy the example config and customize it for your AWS account:
+
+```bash
+cd server
+cp samconfig.toml.example samconfig.toml
+# Edit samconfig.toml — set your region, stack name, and AWS profile
+```
+
+`samconfig.toml` is gitignored so your local config stays out of version control.
+
+## 3. Deploy manually
+
+```bash
+# Build client
+cd client && npm ci && npm run build && cd ..
+
+# Build server
+cd server && sam build
+
+# Bundle client SPA into Lambda artifacts
+cp -r ../client/dist .aws-sam/build/PlatoStreamFunction/client-dist
+cp -r ../client/dist .aws-sam/build/PlatoApiFunction/client-dist
+
+# Bundle content source files (prompts, lessons) for seeding
+mkdir -p .aws-sam/build/PlatoApiFunction/client-content .aws-sam/build/PlatoStreamFunction/client-content
+cp -r ../client/prompts ../client/data .aws-sam/build/PlatoApiFunction/client-content/
+cp -r ../client/prompts ../client/data .aws-sam/build/PlatoStreamFunction/client-content/
+
+# Generate version.json from the latest Beta-RC-* tag
+VERSION=$(git describe --tags --abbrev=0 --match='Beta-RC-*' 2>/dev/null || echo 'Beta-RC-0')
+echo "{\"version\":\"${VERSION}\"}" > .aws-sam/build/PlatoApiFunction/version.json
+cp .aws-sam/build/PlatoApiFunction/version.json .aws-sam/build/PlatoStreamFunction/version.json
+
+# Deploy (default stage is prod)
+sam deploy
+# Or deploy a specific stage
+sam deploy --parameter-overrides Stage=playground --stack-name plato-playground
+```
+
+The `Stage` parameter controls DynamoDB table name prefixes and SSM parameter paths. See `server/template.yaml` for the full infrastructure definition.
+
+## 4. Set up CI/CD (recommended)
+
+For production deployments, we recommend automating deploys from a **private fork** via GitHub Actions. This keeps your AWS credentials and deploy config out of the public repo. The flow here uses `repository_dispatch`: pushing to the public repo fires a dispatch event to the private fork, which runs the actual deploy. No manual pushing to the deploy remote, and the deploy workflows never need to exist in the public repo.
+
+**Create a private fork:**
+
+```bash
+gh repo fork 1111philo/plato --fork-name my-plato --org my-org --clone=false
+gh repo edit my-org/my-plato --visibility private --accept-visibility-change-consequences
+```
+
+**Set up OIDC authentication** (no static AWS keys needed):
+
+1. Ensure your AWS account has a GitHub OIDC provider (one-time setup):
+   ```bash
+   aws iam create-open-id-connect-provider \
+     --url https://token.actions.githubusercontent.com \
+     --client-id-list sts.amazonaws.com \
+     --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1
+   ```
+
+2. Create an IAM role that GitHub Actions can assume. The trust policy should allow your private fork repo:
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [{
+       "Effect": "Allow",
+       "Principal": {
+         "Federated": "arn:aws:iam::YOUR_ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
+       },
+       "Action": "sts:AssumeRoleWithWebIdentity",
+       "Condition": {
+         "StringEquals": { "token.actions.githubusercontent.com:aud": "sts.amazonaws.com" },
+         "StringLike": { "token.actions.githubusercontent.com:sub": "repo:my-org/my-plato:*" }
+       }
+     }]
+   }
+   ```
+
+3. Attach a permissions policy to the role with access to CloudFormation, Lambda, S3, API Gateway, DynamoDB, IAM (for role creation), and SSM (parameter reads).
+
+**Create a dispatch token:** In GitHub, generate a fine-grained personal access token with `contents:write` permission scoped to your private fork. Add it to the **public repo** as a secret named `DEPLOY_DISPATCH_TOKEN`. The public repo's trigger workflow uses this token to fire dispatch events at the private fork.
+
+**The trigger workflow** lives in the public repo at `.github/workflows/trigger-deploy.yml` (already included in this project). On push to `main` or `playground`, it fires a `deploy-prod` or `deploy-playground` `repository_dispatch` event at the private fork with the commit SHA as payload.
+
+**Add a deploy workflow** to your private fork at `.github/workflows/deploy.yml`:
+
+```yaml
+name: Deploy to AWS
+
+on:
+  repository_dispatch:
+    types: [deploy-prod]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Ref on the public repo to deploy (branch / tag / SHA)'
+        required: false
+        default: 'main'
+
+env:
+  SOURCE_REPO: my-org/my-plato-source  # your public repo
+  SOURCE_REF: ${{ github.event.client_payload.sha || inputs.ref || 'main' }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ env.SOURCE_REPO }}
+          ref: ${{ env.SOURCE_REF }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: cd server && npm ci && npm test
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ env.SOURCE_REPO }}
+          ref: ${{ env.SOURCE_REF }}
+          fetch-depth: 0  # need history + tags so we can read the latest Beta-RC-* tag
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::YOUR_ACCOUNT_ID:role/YOUR_DEPLOY_ROLE
+          aws-region: YOUR_REGION
+      - run: cd client && npm ci && npm run build
+      - run: cd server && sam build
+      - run: |
+          cp -r client/dist server/.aws-sam/build/PlatoApiFunction/client-dist
+          cp -r client/dist server/.aws-sam/build/PlatoStreamFunction/client-dist
+      - run: |
+          mkdir -p server/.aws-sam/build/PlatoApiFunction/client-content server/.aws-sam/build/PlatoStreamFunction/client-content
+          cp -r client/prompts client/data server/.aws-sam/build/PlatoApiFunction/client-content/
+          cp -r client/prompts client/data server/.aws-sam/build/PlatoStreamFunction/client-content/
+      - name: Generate version.json from latest tag
+        run: |
+          VERSION=$(git describe --tags --abbrev=0 --match='Beta-RC-*' 2>/dev/null || echo 'Beta-RC-0')
+          echo "{\"version\":\"${VERSION}\"}" > server/.aws-sam/build/PlatoApiFunction/version.json
+          cp server/.aws-sam/build/PlatoApiFunction/version.json server/.aws-sam/build/PlatoStreamFunction/version.json
+      - run: >
+          cd server && sam deploy
+          --config-env ci
+          --stack-name plato
+          --region YOUR_REGION
+          --s3-bucket YOUR_SAM_S3_BUCKET
+          --s3-prefix plato
+          --capabilities CAPABILITY_IAM
+          --no-confirm-changeset
+          --no-fail-on-empty-changeset
+          --parameter-overrides Stage=prod
+```
+
+Replace `YOUR_ACCOUNT_ID`, `YOUR_DEPLOY_ROLE`, `YOUR_REGION`, `YOUR_SAM_S3_BUCKET`, and `SOURCE_REPO` with your values. The S3 bucket is the one SAM creates on first manual deploy (named `aws-sam-cli-managed-default-samclisourcebucket-*`).
+
+**Pre-deploy backups:** Add a step before `sam deploy` to back up your DynamoDB tables. For example, loop over your table names and call `aws dynamodb create-backup` for each, then prune old backups (keeping the last 5 per table).
+
+**Multiple environments:** For a staging environment (e.g., `playground`), add a second workflow to the private fork that listens on `repository_dispatch` type `deploy-playground` and deploys with `--stack-name plato-playground --parameter-overrides Stage=playground`. Each stage gets its own DynamoDB tables and SSM parameters. The trigger workflow in the public repo already fires `deploy-playground` on push to the `playground` branch.
+
+**Workflow:** Push or merge to the public repo's `main` or `playground` — the trigger workflow fires the dispatch, the private fork's deploy workflow picks it up, checks out the public repo at that SHA, runs tests, and deploys. Tests run first — deploy only happens if they pass. For re-deploying a specific SHA manually, use `workflow_dispatch` on the private fork's deploy workflow with an optional `ref` input.
+
+## Custom domain (optional)
+
+To serve the app from a custom domain:
+
+1. Create a CloudFront distribution with the Lambda Function URL as a **Custom Origin** (HTTPS-only)
+2. Set the Origin Request Policy to **AllViewerExceptHostHeader** (required for Lambda Function URLs)
+3. Set the Cache Policy to **CachingDisabled** (the Lambda handles caching headers)
+4. Add your domain as a CloudFront alternate domain name and attach an ACM certificate (must be in us-east-1)
+5. Point your DNS (CNAME or alias) to the CloudFront distribution domain
+
+## Backups
+
+Production DynamoDB tables are protected by two backup layers:
+
+- **Point-in-Time Recovery (PITR)** — enabled on all 5 prod tables, allowing restore to any second in the last 35 days. Handles accidental deletes, data corruption, or bugs discovered after the fact.
+- **Pre-deploy snapshots** — the CI/CD deploy workflow automatically creates on-demand backups of all prod tables before each deploy. Old backups are pruned to keep the last 5 per table. These provide named restore points tied to specific deploys.
+
+To restore from a pre-deploy snapshot, use the AWS Console (DynamoDB > Backups) or the CLI:
+
+```bash
+aws dynamodb restore-table-from-backup \
+  --target-table-name plato-users-restored \
+  --backup-arn arn:aws:dynamodb:us-east-2:ACCOUNT:table/plato-users/backup/BACKUP_ID
+```
+
+To restore from PITR:
+
+```bash
+aws dynamodb restore-table-to-point-in-time \
+  --source-table-name plato-users \
+  --target-table-name plato-users-restored \
+  --restore-date-time 2026-04-01T12:00:00Z
+```
+
+In both cases, DynamoDB restores to a new table — rename or swap as needed.


### PR DESCRIPTION
## Summary

README was ~450 lines and most of it was deploy / architecture / accessibility detail that buries what a first-visit reader actually needs. New README is ~115 lines.

## What moved where

| Content | From | To |
|---------|------|----|
| AWS deploy (SSM, SAM, CI/CD, custom domain, backups — ~200 lines) | README | \`docs/DEPLOY.md\` (new) |
| Architecture tables (Client dirs, Server, AI agents) | README | CLAUDE.md (already had them) |
| Chat-interface accessibility implementation spec | README | CLAUDE.md (already had them) |
| Versioning section | README | CONTRIBUTING.md (already has it) |

## What stayed / was elevated

- **Reporting issues** is now right after "How it works" — first-time readers see it before scrolling through setup
- How plato works + pacing table — unchanged
- Quick start + AI provider — unchanged
- Project layout, Accessibility summary, Contributing, License — kept concise

## Other

- All "open-source" / "open source" references now read "Open Source" — applied to README, CLAUDE.md, knowledge-base-editor.md, lesson-creator.md.

## Test plan

- [ ] Preview rendered README on the PR page
- [ ] Confirm all links work (docs/DEPLOY.md, CLAUDE.md, CONTRIBUTING.md)