### PR TITLE
Fail code-review job when no claude[bot] review posted

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -93,3 +93,20 @@ jobs:
             - Clean → `gh pr review $PR_NUMBER --approve --body "Tests pass. No bugs, security, or accessibility issues found."`
 
             Be direct. Short is better than thorough.
+      - name: Verify claude[bot] review was posted
+        if: steps.guard.outputs.skip != 'true' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # The SDK can exit successfully without calling `gh pr review`,
+          # leaving the PR unreviewed and the required status check green.
+          # Fail loudly instead so the workflow can be re-triggered.
+          COUNT=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
+            --jq "[.[] | select(.user.login==\"claude[bot]\") | select(.commit_id==\"$HEAD_SHA\")] | length")
+          if [ "${COUNT:-0}" -eq 0 ]; then
+            echo "::error::No claude[bot] review posted for $HEAD_SHA. Re-run the workflow or comment @claude on the PR."
+            exit 1
+          fi
+          echo "claude[bot] review exists for $HEAD_SHA"


### PR DESCRIPTION
## Summary

- The Claude Code SDK can exit successfully without calling `gh pr review`, leaving the PR silently unreviewed while the required `review` status check passes green.
- Observed on PR #86 run 24680555185: 9 turns, \$0.18, `is_error: false`, zero permission denials, no review posted. Required a manual `@claude` re-trigger.
- Add a post-step that queries the reviews API for `HEAD_SHA` after the action runs and fails the job if no claude[bot] review exists. Scoped to `pull_request` events to match the guard step.

## Test plan

- [ ] This PR itself exercises the new step — review should post, verify step should pass
- [ ] If the agent silently no-ops again, the job will fail with `::error::No claude[bot] review posted for <sha>` and block merge until re-triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)