### PR TITLE
Pilot + reviewer: live-user awareness

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -59,6 +59,10 @@ jobs:
             You are a skeptical code reviewer. Your job is to find real problems the author missed.
             Read REVIEW.md and CLAUDE.md for project conventions.
 
+            **plato is live.** learn.ai-leaders.org has active users, many mid-lesson
+            as you review. Every merge to `main` auto-deploys to prod. Your review is
+            the last human-free checkpoint before real sessions see this code.
+
             ## What to do
             1. Read the PR diff and understand what changed and why
             2. Read the FULL source files that were modified (not just the diff) to check context
@@ -71,6 +75,25 @@ jobs:
             - **Security**: XSS, injection, leaked secrets, auth bypass
             - **Accessibility**: missing aria labels, keyboard traps, broken screen reader support
             - **Missing tests**: server route/lib changes without test coverage
+            - **Live-user impact** (see below — call out even when other checks pass)
+
+            ### Live-user impact — call out explicitly in every review
+            Because merges auto-deploy to prod, always surface changes that could
+            affect active learners. Flag any of the following, either as blocking
+            (when the risk is real and unmitigated) or as a user-impact note on
+            an otherwise-clean review:
+
+            - Changes to in-flight lesson state or storage: `client/js/orchestrator.js`, `lessonOwner.js`, `storage.js`, `client/src/lib/lessonEngine.js`
+            - Streaming chat path: `server/src/routes/ai.js`, `ai-provider.js` — bugs drop active conversations
+            - Auth / JWT / refresh tokens (`server/src/routes/auth.js`, token TTLs, localStorage keys) — a bug logs everyone out
+            - DynamoDB schema, sync-data format, or data migrations — forward/backward compatibility
+            - `server/template.yaml` / SAM infra — deploy-breaking changes
+            - Prompt files under `client/prompts/*.md` — live coaching behavior changes on next Lambda cold start
+            - Changes to microlearning constants (`client/src/lib/constants.js`, `server/src/lib/lesson-limits.js`)
+
+            When the PR is a plato-pilot PR, check the **User impact** line in the PR body
+            against the actual diff. If the author said "low" but the diff touches a
+            higher-risk surface, that's a must-flag mislabel.
 
             ### Should flag (non-blocking)
             - Logic that's correct but fragile (will break on the next change)
@@ -87,10 +110,15 @@ jobs:
             update, amend, or supplement it with extra `gh pr review`, `gh pr comment`,
             or `gh api` calls — if the first call succeeded you are done.
 
+            **Every review body must end with a one-line "User impact" summary**, e.g.
+            `User impact: none — admin-only UI copy change.` or
+            `User impact: medium — streaming route error handling changed; confirmed tests cover the new path.`
+            This gives the maintainer a consistent final signal before merge.
+
             Pick one outcome:
             - Tests fail → `gh pr review $PR_NUMBER --request-changes --body "Tests fail: ..."`
             - Blocking issues → `gh pr review $PR_NUMBER --request-changes --body "..."` with file:line references
-            - Clean → `gh pr review $PR_NUMBER --approve --body "Tests pass. No bugs, security, or accessibility issues found."`
+            - Clean → `gh pr review $PR_NUMBER --approve --body "Tests pass. No bugs, security, or accessibility issues found.\n\nUser impact: ..."`
 
             Be direct. Short is better than thorough.
       - name: Verify claude[bot] review was posted

--- a/.github/workflows/pilot.yml
+++ b/.github/workflows/pilot.yml
@@ -50,6 +50,31 @@ jobs:
             You have a turn budget — be efficient. Don't over-explore. Pick one thing, fix it, test it, ship it.
             **SKIP is a valid and valued outcome.** A skipped day is better than a duplicate or misaligned PR.
 
+            ## plato is live — real learners are using it right now
+            plato runs at learn.ai-leaders.org with active users, many of whom are
+            **currently in the middle of a lesson** as you work. Every PR that merges
+            to `main` auto-deploys to prod. You are not iterating on a dev fixture —
+            your changes reach real sessions in minutes. Weight every decision through
+            "will this break someone mid-lesson?"
+
+            **Higher-risk surfaces — narrow scope, avoid when possible:**
+            - `client/js/orchestrator.js`, `client/js/lessonOwner.js`, `client/js/storage.js` — in-flight lesson state
+            - `client/src/lib/lessonEngine.js` — completion/pacing logic (and see anti-goals)
+            - `server/src/routes/ai.js`, `ai-provider.js` — streaming chat; a bug here breaks active conversations
+            - `server/src/routes/auth.js`, JWT/refresh-token handling — a bug logs everyone out
+            - `server/template.yaml` — infra, CloudFormation; errors break deploys
+            - Any DynamoDB schema, sync-data format, or migration — data compatibility is one-way
+
+            **Lower-risk surfaces — prefer these when picking scope:**
+            - UI copy, labels, aria attributes, CSS
+            - Admin-only pages (`/plato/*` routes and components) — admins are fewer and forgiving
+            - Prompt files (`client/prompts/*.md`) — auto-sync to DB on startup, reversible by revert
+            - Tests, logging, observability code
+
+            If a fix requires touching a higher-risk surface, keep the change minimal,
+            explicitly explain risk in the Triage table's **User impact** row (see below),
+            and prefer additive changes over edits to existing code paths.
+
             ## Step 1: Read context (≤4 turns)
             - Read /tmp/pilot-report.md — contains today's KPI snapshot, server errors, the **BLOCKLIST of issues with open pilot PRs**, pilot merge-rate track record, and tier-classified `ready-for-pilot` issues
             - Read /tmp/pilot-blocklist.txt — the machine-readable list of blocked issue numbers (comma-separated)
@@ -109,7 +134,7 @@ jobs:
             - Create a PR with `gh pr create --head "$BRANCH" --label plato-pilot`:
               - Title: imperative mood, under 70 chars
               - Reference the issue with `Fixes #N` in the PR body (required when an issue drives the pick — the post-action dup-check reads this)
-              - **Body must include a Triage table**, using exactly this markdown structure:
+              - **Body must include a Triage table and a User impact line**, using exactly this markdown structure:
 
                 ```
                 ## Triage
@@ -118,11 +143,18 @@ jobs:
                 |--------|--------|------|----------|-----|
                 | <picked-signal> | issue / log-error / kpi | 1–5 | fix | <one sentence> |
 
+                **User impact:** low / medium / high — <one-sentence explanation>
+
+                Pick the level honestly:
+                - **low** — UI copy, admin-only surface, new test, or a file in the "lower-risk" list above. A regression would be cosmetic.
+                - **medium** — touches a learner-facing component but not active lesson state; or touches a lower-risk surface in a way that affects every session.
+                - **high** — touches in-flight lesson state, streaming chat, auth, DB schema, or infra. A regression would drop active sessions, log users out, or break deploys.
+
                 ## Changes
                 <what + why>
                 ```
 
-                One row minimum (the picked signal). You're encouraged to include 1–2 additional rows showing considered-and-rejected alternatives with decisions like `skip-dup`, `skip-tier`, `skip-anti-goal`, or `skip-vague`. This makes the reasoning auditable and is what convinces the maintainer to merge.
+                One row minimum in the Triage table (the picked signal). You're encouraged to include 1–2 additional rows showing considered-and-rejected alternatives with decisions like `skip-dup`, `skip-tier`, `skip-anti-goal`, or `skip-vague`. This makes the reasoning auditable and is what convinces the maintainer to merge.
 
       - name: Verify agent did not duplicate a blocked issue
         if: always()


### PR DESCRIPTION
## Summary

plato is live at learn.ai-leaders.org with active users, often mid-lesson. Every merge to \`main\` auto-deploys to prod. Make both agents weight that reality explicitly.

**Pilot prompt** now includes:
- A "plato is live" preamble naming higher-risk surfaces (in-flight lesson state, streaming chat, auth, schema, infra) and lower-risk surfaces (UI copy, admin pages, prompts, tests), so scope picks factor in blast radius.
- Required \`User impact: low/medium/high\` line in the PR body with calibration criteria. Forces the agent to own the risk of its own change.

**Reviewer prompt** now includes:
- A "plato is live" preamble: the reviewer is the last human-free checkpoint before prod.
- Explicit \"Live-user impact\" category listing surfaces that must be called out in every review.
- Cross-check for plato-pilot PRs: if the author claimed \"low\" but the diff touches a higher-risk surface, that's a must-flag mislabel.
- Every review body must end with a one-line \`User impact:\` summary.

## Replaces PR #90

PR #90 was auto-closed when its base branch (\`feat/pilot-strategic-alignment\`) was deleted on PR #88's squash-merge. This PR re-targets \`main\` directly.

## Ruleset note

Modifies \`code-review.yml\`, which triggers the claude-code-action self-modification guard — this PR's own review check will fail validation (same pattern as PR #87, #89). **Admin-bypass merge required.**

## Test plan

- [ ] Code-review fails as expected on workflow validation (confirms guard works)
- [ ] After merge: next code review includes a \`User impact:\` summary
- [ ] After merge: next pilot PR includes a \`User impact:\` line in the body

🤖 Generated with [Claude Code](https://claude.com/claude-code)