### PR TITLE
Pilot: flip auto-escalate to live mode

### DIFF
--- a/.github/workflows/pilot.yml
+++ b/.github/workflows/pilot.yml
@@ -193,15 +193,18 @@ jobs:
           if [ "$FAILED" -eq 1 ]; then exit 1; fi
           echo "Post-action dup-check passed."
 
-      - name: Auto-escalate looping issues (dry-run)
+      - name: Auto-escalate looping issues
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DRY_RUN: 'true'
+          DRY_RUN: 'false'
         run: |
           # Find ready-for-pilot issues that have ≥2 closed-unmerged pilot PRs.
-          # In dry-run mode (default for first week), log what we would do.
-          # Flip DRY_RUN=false to enable real relabel + comment.
+          # When a loop is detected: relabel ready-for-pilot → needs-info and
+          # post a comment asking the reporter to clarify. The dry-run mode
+          # (DRY_RUN=true) was used for the first run on 2026-04-20 and
+          # produced correct output (would-relabel #60, skip #43 because
+          # it's not labeled). Flipped to live after that validation.
           SINCE=$(date -u -d '30 days ago' +%Y-%m-%d 2>/dev/null || date -u -v-30d +%Y-%m-%d)
           CLOSED_PRS=$(gh pr list --label plato-pilot --state closed --limit 50 \
             --search "closed:>=$SINCE" \


### PR DESCRIPTION
## Summary

The auto-escalation step in \`pilot.yml\` was deployed in dry-run mode (PR #88) as defensive insurance. Today's first real execution produced correct output:

- \`[DRY-RUN] Would relabel issue #60 (ready-for-pilot → needs-info) after 2 closed pilot PRs.\` — exactly the case it was built for
- \`Issue #43 has 2 closed pilot PRs but is not ready-for-pilot; skip.\` — correct no-op when label isn't present

The logic is deterministic; another week of dry-run wouldn't teach us anything new. Flipping to live.

## Effect on the next pilot run

Issue #60 (the loop that motivated this whole effort) will get its \`ready-for-pilot\` label removed, gain \`needs-info\`, and receive a comment listing the closed PRs and asking the reporter to clarify which (if any) matches their intent.

## Test plan

- [ ] Code-review passes (no functional code change, just env var + comment update)
- [ ] Next pilot run relabels #60 as expected and posts the clarifying comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)