### PR TITLE
Remove ANTHROPIC_API_KEY fallback; OAuth-only for all Claude workflows

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -47,9 +47,7 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         with:
-          # Prefer Claude Max OAuth; fall back to API key if the secret isn't set.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "claude"
           # display_report intentionally disabled: it auto-posts an aggregated
           # review from buffered inline annotations at end of session, which

--- a/.github/workflows/issue-intake.yml
+++ b/.github/workflows/issue-intake.yml
@@ -49,9 +49,7 @@ jobs:
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
         with:
-          # Prefer Claude Max OAuth; fall back to API key if the secret isn't set.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "claude"
           show_full_output: true
           claude_args: "--allowedTools Bash(*),Read(*),Glob,Grep --max-turns 15"

--- a/.github/workflows/pilot.yml
+++ b/.github/workflows/pilot.yml
@@ -42,9 +42,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         id: agent
         with:
-          # Prefer Claude Max OAuth; fall back to API key if the secret isn't set.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true
           claude_args: "--allowedTools Bash(*),Read(*),Write(*),Edit,Glob,Grep --max-turns 50"
           prompt: |

--- a/.github/workflows/revise.yml
+++ b/.github/workflows/revise.yml
@@ -42,7 +42,7 @@ jobs:
           REVIEW_ID: ${{ github.event.review.id }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "claude"
           show_full_output: true
           claude_args: "--allowedTools Bash(*),Read(*),Write(*),Edit,Glob,Grep --max-turns 30"


### PR DESCRIPTION
## Summary

OAuth was validated live on 2026-04-20 across all three workflows (pilot SKIPPED correctly, issue-intake ran on #46, code-review approved PR #85). Removing the API-key fallback.

## Files

- \`pilot.yml\`, \`code-review.yml\`, \`issue-intake.yml\` — drop \`anthropic_api_key:\` input, keep only \`claude_code_oauth_token:\`
- \`revise.yml\` — was missed in the initial OAuth migration; swap \`anthropic_api_key\` for \`claude_code_oauth_token\`. This workflow responds to \`changes_requested\` reviews on pilot PRs.

## Secret lifecycle

The \`ANTHROPIC_API_KEY\` repo secret is **left in place** for quick rollback. Once this has been live for a while, delete the secret manually.

## Test plan

- [ ] Code-review on this PR uses OAuth-only (same auth everyone else uses now)
- [ ] If anything breaks, revert this PR — the secret is still available
- [ ] Later: confirm \`revise.yml\` works on OAuth next time a pilot PR gets \`changes_requested\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)