### PR TITLE
Reject oversized images before sending to Bedrock

### DIFF
--- a/client/src/lib/lessonEngine.js
+++ b/client/src/lib/lessonEngine.js
@@ -15,8 +15,8 @@ import {
 } from '../../js/storage.js';
 import * as orchestrator from '../../js/orchestrator.js';
 import { syncInBackground } from './syncDebounce.js';
-import { ensureProfileExists, updateProfileInBackground, updateProfileOnCompletionInBackground, updateProfileFromObservation } from './profileQueue.js';
-import { LESSON_PHASES, MSG_TYPES, MAX_EXCHANGES } from './constants.js';
+import { ensureProfileExists, updateProfileFromObservation, updateProfileOnCompletionInBackground } from './profileQueue.js';
+import { LESSON_PHASES, MSG_TYPES } from './constants.js';
 
 function ts() { return Date.now(); }
 
@@ -193,8 +193,7 @@ export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream
   const messages = [{ role: 'user', content: contextMsg }, { role: 'assistant', content: 'Ready.' }, ...tail];
   messages.push({ role: 'user', content: userParts.length === 1 && !imageDataUrl ? text : userParts });
 
-  // Call coach (use heavy model if image attached)
-  const model = imageDataUrl ? 'heavy' : undefined;
+  // Call coach
   const coachMsg = await orchestrator.converseStream(
     'coach',
     messages,
@@ -237,9 +236,12 @@ export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream
   await saveLessonKB(lessonId, lessonKB);
   syncInBackground(`lessonKB:${lessonId}`);
 
-  // Profile updates — from explicit tag or from KB insights
-  if (parsed.profileUpdate) {
-    updateProfileInBackground(parsed.profileUpdate);
+  // Profile updates — from explicit tag or from KB insights as fallback
+  if (parsed.profileUpdate?.observation) {
+    updateProfileFromObservation(lessonKB, parsed.profileUpdate.observation);
+  } else if (parsed.kbUpdate?.insights?.length) {
+    const insightText = parsed.kbUpdate.insights.join('. ');
+    updateProfileFromObservation(lessonKB, insightText);
   }
 
   // Save messages
@@ -264,7 +266,7 @@ export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream
   syncInBackground(`lessonKB:${lessonId}`, `messages:${lessonId}`);
 
   if (achieved) {
-    updateProfileOnCompletionInBackground(lessonKB, lesson.name, lessonId);
+    updateProfileOnCompletionInBackground(lessonKB, lesson);
   }
 
   return {
@@ -274,6 +276,17 @@ export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream
   };
 }
 
+/**
+ * Resume an existing lesson — loads stored messages and KB.
+ */
+export async function resumeLesson(lessonId) {
+  const messages = await getLessonMessages(lessonId);
+  const lessonKB = await getLessonKB(lessonId);
+  const progress = lessonKB?.progress ?? 0;
+  const phase = lessonKB?.status === 'completed' ? LESSON_PHASES.COMPLETED : LESSON_PHASES.LEARNING;
+  return { messages, lessonKB, progress, phase };
+}
+
 // -- Context builder ----------------------------------------------------------
 
 /**
@@ -281,12 +294,12 @@ export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream
  * coach turn. Keeps the coach grounded in lesson state and learner progress.
  */
 export function buildContext(lesson, lessonKB, profileSummary, learnerName) {
-  const exchanges = lessonKB.activitiesCompleted || 0;
+  const exchanges = lessonKB?.activitiesCompleted || 0;
 
   // Escalating pacing directive based on exchange count
   let pacingDirective = null;
   if (exchanges >= 20) {
-    pacingDirective = 'CRITICAL: This lesson has run very long. The learner must reach the exemplar THIS exchange — synthesize, affirm any reasonable attempt, and award progress 10 now.';
+    pacingDirective = 'This lesson has run well past its target length. If the learner has demonstrated the exemplar (or something close to it), this is a good moment to award progress 10 and close warmly. If they are still genuinely working toward it, keep moving them forward — prefer smaller, more concrete steps.';
   } else if (exchanges >= 15) {
     pacingDirective = 'URGENT: Lesson is significantly over target. Push strongly toward the exemplar — reduce scaffolding, prompt directly for the final demonstration, and award progress 10 as soon as the learner shows adequate understanding.';
   } else if (exchanges >= 11) {

--- a/client/src/lib/lessonEngine.js
+++ b/client/src/lib/lessonEngine.js
@@ -20,6 +20,10 @@ import { LESSON_PHASES, MSG_TYPES, MAX_EXCHANGES } from './constants.js';
 
 function ts() { return Date.now(); }
 
+// Bedrock hard limit for base64-encoded image payloads.
+// 5 MB decoded = 5 * 1024 * 1024 bytes. Base64 string length * 3/4 ≈ decoded bytes.
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
 // -- Tag parsing --------------------------------------------------------------
 
 // Detects where the coach tag section begins (tags always come at the end)
@@ -145,6 +149,21 @@ export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream
   let lessonKB = await getLessonKB(lessonId);
   const profileSummary = await getLearnerProfileSummary();
 
+  // Validate image size before sending — Bedrock rejects base64 images > 5 MB.
+  // base64 string length * 3/4 ≈ decoded byte count.
+  if (imageDataUrl) {
+    const match = imageDataUrl.match(/^data:image\/\w+;base64,(.+)$/);
+    if (match) {
+      const estimatedBytes = Math.floor(match[1].length * 3 / 4);
+      if (estimatedBytes > MAX_IMAGE_BYTES) {
+        throw new Error(
+          `Image is too large (${(estimatedBytes / (1024 * 1024)).toFixed(1)} MB). ` +
+          `Please resize it to under 5 MB and try again.`
+        );
+      }
+    }
+  }
+
   // Save image if provided
   let imageKey = null;
   if (imageDataUrl) {
@@ -218,81 +237,74 @@ export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream
   await saveLessonKB(lessonId, lessonKB);
   syncInBackground(`lessonKB:${lessonId}`);
 
-  // Profile updates — from explicit tag or from KB insights as fallback
-  if (parsed.profileUpdate?.observation) {
-    updateProfileFromObservation(lessonKB, parsed.profileUpdate.observation);
-  } else if (parsed.kbUpdate?.insights?.length) {
-    // Use KB insights as a profile signal if no explicit profile update
-    const insightText = parsed.kbUpdate.insights.join('. ');
-    updateProfileFromObservation(lessonKB, insightText);
-  }
-  if (achieved) {
-    updateProfileOnCompletionInBackground(lessonKB, lesson);
+  // Profile updates — from explicit tag or from KB insights
+  if (parsed.profileUpdate) {
+    updateProfileInBackground(parsed.profileUpdate);
   }
 
   // Save messages
-  const newMessages = [
-    { role: 'user', content: text || (imageKey ? '[image]' : ''), msgType: MSG_TYPES.USER, phase: LESSON_PHASES.LEARNING,
-      metadata: imageKey ? { imageKey } : null, timestamp: ts() },
-    { role: 'assistant', content: parsed.text, msgType: MSG_TYPES.GUIDE,
-      phase: achieved ? LESSON_PHASES.COMPLETED : LESSON_PHASES.LEARNING, timestamp: ts() },
-  ];
+  const userMsg = {
+    role: 'user',
+    content: text || '',
+    imageKey,
+    msgType: MSG_TYPES.USER,
+    phase: LESSON_PHASES.LEARNING,
+    timestamp: ts(),
+  };
+  const assistantMsg = {
+    role: 'assistant',
+    content: parsed.text,
+    msgType: MSG_TYPES.GUIDE,
+    phase: achieved ? LESSON_PHASES.COMPLETED : LESSON_PHASES.LEARNING,
+    timestamp: ts(),
+  };
 
-  await saveLessonMessages(lessonId, newMessages);
-  syncInBackground(`messages:${lessonId}`);
+  const updatedMsgs = [...(await getLessonMessages(lessonId)), userMsg, assistantMsg];
+  await saveLessonMessages(lessonId, updatedMsgs);
+  syncInBackground(`lessonKB:${lessonId}`, `messages:${lessonId}`);
 
-  return { messages: newMessages, progress: parsed.progress, achieved, phase: achieved ? LESSON_PHASES.COMPLETED : LESSON_PHASES.LEARNING };
+  if (achieved) {
+    updateProfileOnCompletionInBackground(lessonKB, lesson.name, lessonId);
+  }
+
+  return {
+    messages: updatedMsgs,
+    lessonKB,
+    phase: achieved ? LESSON_PHASES.COMPLETED : LESSON_PHASES.LEARNING,
+  };
 }
+
+// -- Context builder ----------------------------------------------------------
 
 /**
- * Resume an existing lesson. Loads messages and KB.
+ * Build the JSON context block injected as the first user message on every
+ * coach turn. Keeps the coach grounded in lesson state and learner progress.
  */
-export async function resumeLesson(lessonId) {
-  const messages = await getLessonMessages(lessonId);
-  const lessonKB = await getLessonKB(lessonId);
-  const progress = lessonKB?.progress ?? 0;
-  const phase = lessonKB?.status === 'completed' ? LESSON_PHASES.COMPLETED : LESSON_PHASES.LEARNING;
-  return { messages, lessonKB, progress, phase };
-}
-
-// -- Helpers ------------------------------------------------------------------
-
 export function buildContext(lesson, lessonKB, profileSummary, learnerName) {
-  const completed = lessonKB?.activitiesCompleted || 0;
-  const context = {
-    learnerName: learnerName || '',
+  const exchanges = lessonKB.activitiesCompleted || 0;
+
+  // Escalating pacing directive based on exchange count
+  let pacingDirective = null;
+  if (exchanges >= 20) {
+    pacingDirective = 'CRITICAL: This lesson has run very long. The learner must reach the exemplar THIS exchange — synthesize, affirm any reasonable attempt, and award progress 10 now.';
+  } else if (exchanges >= 15) {
+    pacingDirective = 'URGENT: Lesson is significantly over target. Push strongly toward the exemplar — reduce scaffolding, prompt directly for the final demonstration, and award progress 10 as soon as the learner shows adequate understanding.';
+  } else if (exchanges >= 11) {
+    pacingDirective = 'PACING: Lesson has exceeded the target length. Consolidate remaining objectives, guide the learner toward a final demonstration, and award progress 10 at the next reasonable opportunity.';
+  } else if (exchanges >= 8) {
+    pacingDirective = 'PACING: Approaching the target length. Begin steering toward closure — wrap up open threads and prepare the learner for a final synthesis.';
+  }
+
+  return JSON.stringify({
+    lessonId: lesson.lessonId,
     lessonName: lesson.name,
     lessonDescription: lesson.description,
     exemplar: lesson.exemplar,
-    objectives: lessonKB?.objectives || [],
-    insights: lessonKB?.insights || [],
-    learnerProfile: profileSummary || 'No profile yet',
-    learnerPosition: lessonKB?.learnerPosition || 'New learner',
-    progress: lessonKB?.progress ?? 0,
-    activitiesCompleted: completed,
-  };
-  // Pacing directives are nudges, not orders. The target (MAX_EXCHANGES) is a
-  // design goal for ~20-minute lessons — never a deadline. The coach always
-  // decides when the learner has demonstrated the exemplar. These messages
-  // help the coach sharpen its focus as exchanges accumulate, but NEVER tell
-  // it to force-close a lesson on the learner.
-  const over = completed - MAX_EXCHANGES;
-  if (over >= 9) {
-    // 20+ exchanges: the lesson has run well past the target. Likely a sign
-    // the lesson design or the learner's starting point mismatched — worth
-    // a reflective note, but still the coach's call to close.
-    context.pacingDirective = 'This lesson has run well past its target length. If the learner has demonstrated the exemplar (or something close to it), this is a good moment to award progress 10 and close warmly. If they are still genuinely working toward it, keep moving them forward — prefer smaller, more concrete steps. Note in [KB_UPDATE] if the lesson design seems to be the issue.';
-  } else if (over >= 4) {
-    // 15+ exchanges: converge hard. Prefer closing when the exemplar is met,
-    // but do not force the issue if the learner is still making progress.
-    context.pacingDirective = 'The lesson has run longer than target. Compress: focus on the single biggest remaining gap. If the learner has demonstrated the exemplar, award progress 10 and close warmly. If they are close, one sharp final step can get them there. Keep moving them forward — never cut them off mid-thought.';
-  } else if (over >= 0) {
-    // 11+ exchanges: target reached. Start to converge.
-    context.pacingDirective = 'Target exchange count reached. Begin converging toward the exemplar — avoid introducing new objectives. If the learner has demonstrated the exemplar, award progress 10. Otherwise give one focused nudge that narrows the gap.';
-  } else if (completed >= MAX_EXCHANGES - 3) {
-    // 8-10 exchanges: pre-target — start converging.
-    const remaining = MAX_EXCHANGES - completed;
-    context.pacingDirective = `Approaching target (${remaining} exchange${remaining === 1 ? '' : 's'} until the ~20-minute design goal). Converge toward the exemplar — one focused task that narrows the gap. You may still introduce new concepts if the learner genuinely needs them to advance.`;
-  }
-  return JSON.stringify(context);
+    learningObjectives: lesson.learningObjectives,
+    learnerName: learnerName || 'Learner',
+    learnerProfile: profileSummary || 'New learner, no profile yet.',
+    lessonKB,
+    exchangeCount: exchanges,
+    ...(pacingDirective ? { pacingDirective } : {}),
+  });
 }

--- a/client/src/lib/lessonEngine.js
+++ b/client/src/lib/lessonEngine.js
@@ -15,14 +15,32 @@ import {
 } from '../../js/storage.js';
 import * as orchestrator from '../../js/orchestrator.js';
 import { syncInBackground } from './syncDebounce.js';
-import { ensureProfileExists, updateProfileFromObservation, updateProfileOnCompletionInBackground } from './profileQueue.js';
-import { LESSON_PHASES, MSG_TYPES } from './constants.js';
+import { ensureProfileExists, updateProfileInBackground, updateProfileOnCompletionInBackground, updateProfileFromObservation } from './profileQueue.js';
+import { LESSON_PHASES, MSG_TYPES, MAX_EXCHANGES } from './constants.js';
 
 function ts() { return Date.now(); }
 
 // Bedrock hard limit for base64-encoded image payloads.
 // 5 MB decoded = 5 * 1024 * 1024 bytes. Base64 string length * 3/4 ≈ decoded bytes.
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Throw a learner-friendly error if an image data URL decodes to more than
+ * 5 MB — Bedrock rejects larger images with a cryptic ValidationException.
+ * Returns silently for non-image URLs or URLs without a parseable base64 body.
+ */
+export function assertImageWithinBedrockLimit(imageDataUrl) {
+  if (!imageDataUrl) return;
+  const match = imageDataUrl.match(/^data:image\/\w+;base64,(.+)$/);
+  if (!match) return;
+  const estimatedBytes = Math.floor(match[1].length * 3 / 4);
+  if (estimatedBytes > MAX_IMAGE_BYTES) {
+    throw new Error(
+      `Image is too large (${(estimatedBytes / (1024 * 1024)).toFixed(1)} MB). ` +
+      `Please resize it to under 5 MB and try again.`
+    );
+  }
+}
 
 // -- Tag parsing --------------------------------------------------------------
 
@@ -149,20 +167,7 @@ export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream
   let lessonKB = await getLessonKB(lessonId);
   const profileSummary = await getLearnerProfileSummary();
 
-  // Validate image size before sending — Bedrock rejects base64 images > 5 MB.
-  // base64 string length * 3/4 ≈ decoded byte count.
-  if (imageDataUrl) {
-    const match = imageDataUrl.match(/^data:image\/\w+;base64,(.+)$/);
-    if (match) {
-      const estimatedBytes = Math.floor(match[1].length * 3 / 4);
-      if (estimatedBytes > MAX_IMAGE_BYTES) {
-        throw new Error(
-          `Image is too large (${(estimatedBytes / (1024 * 1024)).toFixed(1)} MB). ` +
-          `Please resize it to under 5 MB and try again.`
-        );
-      }
-    }
-  }
+  assertImageWithinBedrockLimit(imageDataUrl);
 
   // Save image if provided
   let imageKey = null;
@@ -193,7 +198,8 @@ export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream
   const messages = [{ role: 'user', content: contextMsg }, { role: 'assistant', content: 'Ready.' }, ...tail];
   messages.push({ role: 'user', content: userParts.length === 1 && !imageDataUrl ? text : userParts });
 
-  // Call coach
+  // Call coach (use heavy model if image attached)
+  const model = imageDataUrl ? 'heavy' : undefined;
   const coachMsg = await orchestrator.converseStream(
     'coach',
     messages,
@@ -240,44 +246,30 @@ export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream
   if (parsed.profileUpdate?.observation) {
     updateProfileFromObservation(lessonKB, parsed.profileUpdate.observation);
   } else if (parsed.kbUpdate?.insights?.length) {
+    // Use KB insights as a profile signal if no explicit profile update
     const insightText = parsed.kbUpdate.insights.join('. ');
     updateProfileFromObservation(lessonKB, insightText);
   }
-
-  // Save messages
-  const userMsg = {
-    role: 'user',
-    content: text || '',
-    imageKey,
-    msgType: MSG_TYPES.USER,
-    phase: LESSON_PHASES.LEARNING,
-    timestamp: ts(),
-  };
-  const assistantMsg = {
-    role: 'assistant',
-    content: parsed.text,
-    msgType: MSG_TYPES.GUIDE,
-    phase: achieved ? LESSON_PHASES.COMPLETED : LESSON_PHASES.LEARNING,
-    timestamp: ts(),
-  };
-
-  const updatedMsgs = [...(await getLessonMessages(lessonId)), userMsg, assistantMsg];
-  await saveLessonMessages(lessonId, updatedMsgs);
-  syncInBackground(`lessonKB:${lessonId}`, `messages:${lessonId}`);
-
   if (achieved) {
     updateProfileOnCompletionInBackground(lessonKB, lesson);
   }
 
-  return {
-    messages: updatedMsgs,
-    lessonKB,
-    phase: achieved ? LESSON_PHASES.COMPLETED : LESSON_PHASES.LEARNING,
-  };
+  // Save messages
+  const newMessages = [
+    { role: 'user', content: text || (imageKey ? '[image]' : ''), msgType: MSG_TYPES.USER, phase: LESSON_PHASES.LEARNING,
+      metadata: imageKey ? { imageKey } : null, timestamp: ts() },
+    { role: 'assistant', content: parsed.text, msgType: MSG_TYPES.GUIDE,
+      phase: achieved ? LESSON_PHASES.COMPLETED : LESSON_PHASES.LEARNING, timestamp: ts() },
+  ];
+
+  await saveLessonMessages(lessonId, newMessages);
+  syncInBackground(`messages:${lessonId}`);
+
+  return { messages: newMessages, progress: parsed.progress, achieved, phase: achieved ? LESSON_PHASES.COMPLETED : LESSON_PHASES.LEARNING };
 }
 
 /**
- * Resume an existing lesson — loads stored messages and KB.
+ * Resume an existing lesson. Loads messages and KB.
  */
 export async function resumeLesson(lessonId) {
   const messages = await getLessonMessages(lessonId);
@@ -287,37 +279,44 @@ export async function resumeLesson(lessonId) {
   return { messages, lessonKB, progress, phase };
 }
 
-// -- Context builder ----------------------------------------------------------
+// -- Helpers ------------------------------------------------------------------
 
-/**
- * Build the JSON context block injected as the first user message on every
- * coach turn. Keeps the coach grounded in lesson state and learner progress.
- */
 export function buildContext(lesson, lessonKB, profileSummary, learnerName) {
-  const exchanges = lessonKB?.activitiesCompleted || 0;
-
-  // Escalating pacing directive based on exchange count
-  let pacingDirective = null;
-  if (exchanges >= 20) {
-    pacingDirective = 'This lesson has run well past its target length. If the learner has demonstrated the exemplar (or something close to it), this is a good moment to award progress 10 and close warmly. If they are still genuinely working toward it, keep moving them forward — prefer smaller, more concrete steps.';
-  } else if (exchanges >= 15) {
-    pacingDirective = 'URGENT: Lesson is significantly over target. Push strongly toward the exemplar — reduce scaffolding, prompt directly for the final demonstration, and award progress 10 as soon as the learner shows adequate understanding.';
-  } else if (exchanges >= 11) {
-    pacingDirective = 'PACING: Lesson has exceeded the target length. Consolidate remaining objectives, guide the learner toward a final demonstration, and award progress 10 at the next reasonable opportunity.';
-  } else if (exchanges >= 8) {
-    pacingDirective = 'PACING: Approaching the target length. Begin steering toward closure — wrap up open threads and prepare the learner for a final synthesis.';
-  }
-
-  return JSON.stringify({
-    lessonId: lesson.lessonId,
+  const completed = lessonKB?.activitiesCompleted || 0;
+  const context = {
+    learnerName: learnerName || '',
     lessonName: lesson.name,
     lessonDescription: lesson.description,
     exemplar: lesson.exemplar,
-    learningObjectives: lesson.learningObjectives,
-    learnerName: learnerName || 'Learner',
-    learnerProfile: profileSummary || 'New learner, no profile yet.',
-    lessonKB,
-    exchangeCount: exchanges,
-    ...(pacingDirective ? { pacingDirective } : {}),
-  });
+    objectives: lessonKB?.objectives || [],
+    insights: lessonKB?.insights || [],
+    learnerProfile: profileSummary || 'No profile yet',
+    learnerPosition: lessonKB?.learnerPosition || 'New learner',
+    progress: lessonKB?.progress ?? 0,
+    activitiesCompleted: completed,
+  };
+  // Pacing directives are nudges, not orders. The target (MAX_EXCHANGES) is a
+  // design goal for ~20-minute lessons — never a deadline. The coach always
+  // decides when the learner has demonstrated the exemplar. These messages
+  // help the coach sharpen its focus as exchanges accumulate, but NEVER tell
+  // it to force-close a lesson on the learner.
+  const over = completed - MAX_EXCHANGES;
+  if (over >= 9) {
+    // 20+ exchanges: the lesson has run well past the target. Likely a sign
+    // the lesson design or the learner's starting point mismatched — worth
+    // a reflective note, but still the coach's call to close.
+    context.pacingDirective = 'This lesson has run well past its target length. If the learner has demonstrated the exemplar (or something close to it), this is a good moment to award progress 10 and close warmly. If they are still genuinely working toward it, keep moving them forward — prefer smaller, more concrete steps. Note in [KB_UPDATE] if the lesson design seems to be the issue.';
+  } else if (over >= 4) {
+    // 15+ exchanges: converge hard. Prefer closing when the exemplar is met,
+    // but do not force the issue if the learner is still making progress.
+    context.pacingDirective = 'The lesson has run longer than target. Compress: focus on the single biggest remaining gap. If the learner has demonstrated the exemplar, award progress 10 and close warmly. If they are close, one sharp final step can get them there. Keep moving them forward — never cut them off mid-thought.';
+  } else if (over >= 0) {
+    // 11+ exchanges: target reached. Start to converge.
+    context.pacingDirective = 'Target exchange count reached. Begin converging toward the exemplar — avoid introducing new objectives. If the learner has demonstrated the exemplar, award progress 10. Otherwise give one focused nudge that narrows the gap.';
+  } else if (completed >= MAX_EXCHANGES - 3) {
+    // 8-10 exchanges: pre-target — start converging.
+    const remaining = MAX_EXCHANGES - completed;
+    context.pacingDirective = `Approaching target (${remaining} exchange${remaining === 1 ? '' : 's'} until the ~20-minute design goal). Converge toward the exemplar — one focused task that narrows the gap. You may still introduce new concepts if the learner genuinely needs them to advance.`;
+  }
+  return JSON.stringify(context);
 }

--- a/client/tests/lessonEngine.test.js
+++ b/client/tests/lessonEngine.test.js
@@ -1,0 +1,67 @@
+/**
+ * Tests for lessonEngine helpers.
+ *
+ * Stubs browser globals (localStorage, fetch) before importing the module so
+ * its storage/orchestrator dependencies load cleanly in Node's test runner.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+globalThis.localStorage = {
+  _store: {},
+  getItem(k) { return this._store[k] ?? null; },
+  setItem(k, v) { this._store[k] = v; },
+  removeItem(k) { delete this._store[k]; },
+  clear() { this._store = {}; },
+};
+globalThis.fetch = async () => ({ ok: false, status: 404 });
+
+const { assertImageWithinBedrockLimit } = await import('../src/lib/lessonEngine.js');
+
+// Build a data URL whose base64 body decodes (per length*3/4) to exactly
+// `bytes` bytes. The guard uses the same math so the round-trip is exact.
+// `bytes` must be a multiple of 3.
+function imageDataUrlOfSize(bytes) {
+  if (bytes % 3 !== 0) throw new Error('test helper expects multiple of 3');
+  const b64Len = (bytes / 3) * 4;
+  return `data:image/png;base64,${'A'.repeat(b64Len)}`;
+}
+
+const MAX = 5 * 1024 * 1024;
+
+describe('assertImageWithinBedrockLimit', () => {
+  it('does not throw for undefined or empty input', () => {
+    assert.doesNotThrow(() => assertImageWithinBedrockLimit(undefined));
+    assert.doesNotThrow(() => assertImageWithinBedrockLimit(null));
+    assert.doesNotThrow(() => assertImageWithinBedrockLimit(''));
+  });
+
+  it('does not throw for non-image or non-base64 URLs', () => {
+    assert.doesNotThrow(() => assertImageWithinBedrockLimit('https://example.com/foo.png'));
+    assert.doesNotThrow(() => assertImageWithinBedrockLimit('data:text/plain;base64,SGVsbG8='));
+  });
+
+  it('accepts images at or below the 5 MB Bedrock limit', () => {
+    // MAX (5 * 1024 * 1024 = 5242880) is not divisible by 3; use MAX - 2 which is.
+    assert.doesNotThrow(() => assertImageWithinBedrockLimit(imageDataUrlOfSize(3 * 1024)));
+    assert.doesNotThrow(() => assertImageWithinBedrockLimit(imageDataUrlOfSize(MAX - 2)));
+  });
+
+  it('throws a learner-friendly error above 5 MB', () => {
+    // Next multiple of 3 above MAX: 5242881.
+    const oversized = imageDataUrlOfSize(6 * 1024 * 1024);
+    assert.throws(
+      () => assertImageWithinBedrockLimit(oversized),
+      /Image is too large \(6\.\d MB\)\. Please resize it to under 5 MB/
+    );
+  });
+
+  it('catches the CloudWatch case (~5.38 MB > 5 MB)', () => {
+    // Matches the CloudWatch ValidationException that motivated this guard:
+    // "image exceeds 5 MB maximum: 5639060 bytes > 5242880 bytes".
+    // Round to the nearest multiple of 3 (5639061) for the test encoder.
+    const oversized = imageDataUrlOfSize(5639061);
+    assert.throws(() => assertImageWithinBedrockLimit(oversized), /Image is too large/);
+  });
+});


### PR DESCRIPTION
## Motivation

CloudWatch error in `plato-PlatoStreamFunction`: `ValidationException: messages.9.content.0.image.source.base64: image exceeds 5 MB maximum: 5639060 bytes > 5242880 bytes`. Learners who attach a screenshot just over 5 MB get a silent streaming error instead of a helpful message.

## Changes

Added a `MAX_IMAGE_BYTES` guard in `lessonEngine.js` `sendMessage()`. Before building the message payload, the base64 data string length is converted to decoded byte count (`length * 3 / 4`). If it exceeds 5 MB, the function throws a user-facing error (`'Image is too large...'`) that the UI can surface, rather than sending the oversized payload to Bedrock and getting a cryptic server-side ValidationException.

---
*Proposed by [plato-pilot](https://github.com/UIC-OSF/plato-pilot) — automated KPI-driven suggestions*