### PR TITLE
[codex] Keep completed lesson threads in feedback mode

### DIFF
--- a/client/js/storage.js
+++ b/client/js/storage.js
@@ -11,6 +11,87 @@ import { authenticatedFetch } from './auth.js';
 const _cache = new Map();
 const _versions = new Map();
 
+export class SyncConflictError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = 'SyncConflictError';
+    Object.assign(this, details);
+  }
+}
+
+function randomId(prefix) {
+  if (globalThis.crypto?.randomUUID) return `${prefix}${globalThis.crypto.randomUUID()}`;
+  return `${prefix}${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function lessonSessionKey(lessonId) {
+  return `lessonSession:${lessonId}`;
+}
+
+function createLessonSession(lessonId, generation = 1) {
+  const now = Date.now();
+  return {
+    lessonId,
+    lessonSessionId: randomId('lesson-session-'),
+    generation,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function isLessonSession(data) {
+  return !!data
+    && typeof data.lessonId === 'string'
+    && typeof data.lessonSessionId === 'string'
+    && typeof data.generation === 'number';
+}
+
+function buildLessonGuard(lessonSession) {
+  return lessonSession ? { lessonSessionId: lessonSession.lessonSessionId } : null;
+}
+
+function decorateLessonKB(kb, lessonSession) {
+  if (!lessonSession || !kb || typeof kb !== 'object') return kb;
+  return {
+    ...kb,
+    lessonSessionId: lessonSession.lessonSessionId,
+    lessonSessionGeneration: lessonSession.generation,
+  };
+}
+
+function decorateLessonMessages(messages, lessonSession) {
+  if (!lessonSession) return messages;
+  return messages.map((message) => ({
+    ...message,
+    lessonSessionId: lessonSession.lessonSessionId,
+    lessonSessionGeneration: lessonSession.generation,
+    messageId: message.messageId || randomId('lesson-msg-'),
+  }));
+}
+
+function appendUniqueMessages(existing, incoming) {
+  const merged = Array.isArray(existing) ? [...existing] : [];
+  const seen = new Set(merged.map((message) => message?.messageId).filter(Boolean));
+  for (const message of incoming) {
+    if (message?.messageId && seen.has(message.messageId)) continue;
+    merged.push(message);
+    if (message?.messageId) seen.add(message.messageId);
+  }
+  return merged;
+}
+
+function lessonSessionConflictError(lessonId, lessonSession) {
+  return new SyncConflictError(
+    'Lesson session conflict. This lesson was reset or changed in another tab. Reload the lesson to continue without losing progress.',
+    {
+      code: 'stale_lesson_session',
+      conflict: 'stale_session',
+      lessonId,
+      lessonSession,
+    }
+  );
+}
+
 export function clearCache() {
   _cache.clear();
   _versions.clear();
@@ -22,52 +103,104 @@ export function _populateCache(syncKey, data, version) {
   _versions.set(syncKey, version);
 }
 
-async function fetchSyncData(syncKey) {
-  if (_cache.has(syncKey)) return _cache.get(syncKey);
+async function fetchSyncItem(syncKey, { preferCache = true } = {}) {
+  if (preferCache && _cache.has(syncKey)) {
+    return { data: _cache.get(syncKey), version: _versions.get(syncKey) || 0 };
+  }
   try {
     const res = await authenticatedFetch(`/v1/sync/${encodeURIComponent(syncKey)}`);
-    if (!res.ok) return null;
+    if (!res.ok) return { data: null, version: 0 };
     const item = await res.json();
     _cache.set(syncKey, item.data);
     _versions.set(syncKey, item.version);
-    return item.data;
+    return { data: item.data, version: item.version };
   } catch {
-    return null;
+    return { data: null, version: 0 };
   }
 }
 
+async function fetchSyncData(syncKey, options) {
+  const item = await fetchSyncItem(syncKey, options);
+  return item.data;
+}
+
 /** Write data to the server with optimistic locking. Also exported for syncDebounce. */
-export async function putSyncData(syncKey, data) {
-  _cache.set(syncKey, data);
-  const version = _versions.get(syncKey) || 0;
+export async function putSyncData(syncKey, data, options = {}) {
+  const {
+    version = _versions.get(syncKey) || 0,
+    guard = null,
+    retryOnConflict = true,
+    optimistic = true,
+  } = options;
+
+  if (optimistic) _cache.set(syncKey, data);
+
+  const requestBody = { data, version };
+  if (guard) requestBody.guard = guard;
+
   try {
     const res = await authenticatedFetch(`/v1/sync/${encodeURIComponent(syncKey)}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ data, version }),
+      body: JSON.stringify(requestBody),
     });
+
     if (res.ok) {
       const result = await res.json();
+      _cache.set(syncKey, data);
       _versions.set(syncKey, result.version);
-    } else if (res.status === 409) {
-      // Version conflict — fetch latest version and retry once
-      const current = await authenticatedFetch(`/v1/sync/${encodeURIComponent(syncKey)}`);
-      if (current.ok) {
-        const item = await current.json();
-        _versions.set(syncKey, item.version);
-        const retry = await authenticatedFetch(`/v1/sync/${encodeURIComponent(syncKey)}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ data, version: item.version }),
-        });
-        if (retry.ok) {
-          const retryResult = await retry.json();
-          _versions.set(syncKey, retryResult.version);
-        }
-      }
+      return { ok: true, version: result.version, updatedAt: result.updatedAt };
     }
+
+    if (res.status === 409) {
+      const conflict = await res.json().catch(() => ({}));
+      if (typeof conflict.serverVersion === 'number') {
+        _versions.set(syncKey, conflict.serverVersion);
+      }
+
+      if (!retryOnConflict || conflict.conflict === 'stale_session') {
+        return {
+          ok: false,
+          conflict: conflict.conflict || 'version',
+          serverVersion: conflict.serverVersion ?? null,
+          lessonSession: conflict.lessonSession ?? null,
+          error: conflict.error || 'Version conflict',
+        };
+      }
+
+      // Version conflict — fetch latest version and retry once
+      const current = await fetchSyncItem(syncKey, { preferCache: false });
+      const retry = await authenticatedFetch(`/v1/sync/${encodeURIComponent(syncKey)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          data,
+          version: current.version || 0,
+          ...(guard ? { guard } : {}),
+        }),
+      });
+
+      if (retry.ok) {
+        const retryResult = await retry.json();
+        _cache.set(syncKey, data);
+        _versions.set(syncKey, retryResult.version);
+        return { ok: true, version: retryResult.version, updatedAt: retryResult.updatedAt };
+      }
+
+      const retryConflict = await retry.json().catch(() => ({}));
+      return {
+        ok: false,
+        conflict: retryConflict.conflict || 'version',
+        serverVersion: retryConflict.serverVersion ?? null,
+        lessonSession: retryConflict.lessonSession ?? null,
+        error: retryConflict.error || 'Version conflict',
+      };
+    }
+
+    return { ok: false, error: `Sync failed with status ${res.status}` };
   } catch {
     // Write failed — cache is still updated for this session
+    return { ok: false, error: 'network_error' };
   }
 }
 
@@ -111,16 +244,107 @@ export async function saveLearnerProfileSummary(summary) {
 
 // -- Lesson KB ----------------------------------------------------------------
 
-export async function getLessonKB(lessonId) {
-  return fetchSyncData(`lessonKB:${lessonId}`);
+export async function getLessonSession(lessonId, options) {
+  const data = await fetchSyncData(lessonSessionKey(lessonId), options);
+  return isLessonSession(data) ? data : null;
 }
 
-export async function saveLessonKB(lessonId, kb) {
-  await putSyncData(`lessonKB:${lessonId}`, kb);
+export async function ensureLessonSession(lessonId) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const item = await fetchSyncItem(lessonSessionKey(lessonId), { preferCache: attempt === 0 });
+    if (isLessonSession(item.data)) return item.data;
+
+    const next = createLessonSession(lessonId, (item.data?.generation || 0) + 1);
+    const result = await putSyncData(lessonSessionKey(lessonId), next, {
+      version: item.version || 0,
+      retryOnConflict: false,
+      optimistic: false,
+    });
+    if (result.ok) return next;
+    if (result.conflict === 'version') continue;
+    throw new Error(`Failed to create a lesson session for ${lessonId}.`);
+  }
+  throw new Error(`Failed to create a lesson session for ${lessonId}.`);
+}
+
+async function rotateLessonSession(lessonId) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const item = await fetchSyncItem(lessonSessionKey(lessonId), { preferCache: false });
+    const current = isLessonSession(item.data) ? item.data : null;
+    const next = createLessonSession(lessonId, (current?.generation || 0) + 1);
+    const result = await putSyncData(lessonSessionKey(lessonId), next, {
+      version: item.version || 0,
+      retryOnConflict: false,
+      optimistic: false,
+    });
+    if (result.ok) return next;
+    if (result.conflict === 'version') continue;
+    throw new Error(`Failed to rotate the lesson session for ${lessonId}.`);
+  }
+  throw new Error(`Failed to rotate the lesson session for ${lessonId}.`);
+}
+
+export async function getLessonKB(lessonId, options) {
+  return fetchSyncData(`lessonKB:${lessonId}`, options);
+}
+
+export async function saveLessonKB(lessonId, kb, { lessonSession, version, retryOnConflict = true, optimistic = true } = {}) {
+  const payload = decorateLessonKB(kb, lessonSession);
+  const result = await putSyncData(`lessonKB:${lessonId}`, payload, {
+    version,
+    guard: buildLessonGuard(lessonSession),
+    retryOnConflict,
+    optimistic,
+  });
+  if (!lessonSession) return payload;
+  if (result.ok) return payload;
+  if (result.conflict === 'stale_session') {
+    throw lessonSessionConflictError(lessonId, result.lessonSession);
+  }
+  throw new SyncConflictError('Lesson KB version conflict.', {
+    code: 'lesson_kb_version_conflict',
+    conflict: result.conflict,
+    lessonId,
+  });
 }
 
 export async function deleteLessonKB(lessonId) {
   await deleteSyncData(`lessonKB:${lessonId}`);
+}
+
+export async function updateLessonKB(lessonId, updater, { lessonSession, preferCache = true, maxAttempts = 3 } = {}) {
+  if (!lessonSession) {
+    const previousLessonKB = await getLessonKB(lessonId, { preferCache });
+    const lessonKB = updater(previousLessonKB);
+    await saveLessonKB(lessonId, lessonKB);
+    return { lessonKB, previousLessonKB };
+  }
+
+  const key = `lessonKB:${lessonId}`;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const current = await fetchSyncItem(key, { preferCache: attempt === 0 ? preferCache : false });
+    const previousLessonKB = current.data;
+    const lessonKB = decorateLessonKB(updater(previousLessonKB), lessonSession);
+    const result = await putSyncData(key, lessonKB, {
+      version: current.version || 0,
+      guard: buildLessonGuard(lessonSession),
+      retryOnConflict: false,
+      optimistic: false,
+    });
+
+    if (result.ok) return { lessonKB, previousLessonKB, version: result.version };
+    if (result.conflict === 'version') continue;
+    if (result.conflict === 'stale_session') {
+      throw lessonSessionConflictError(lessonId, result.lessonSession);
+    }
+    throw new Error(`Failed to save lesson progress for ${lessonId}.`);
+  }
+
+  throw new SyncConflictError('Lesson KB stayed in conflict after multiple retries.', {
+    code: 'lesson_kb_conflict_exhausted',
+    conflict: 'version',
+    lessonId,
+  });
 }
 
 // -- Activity KB --------------------------------------------------------------
@@ -213,19 +437,53 @@ export async function deleteDraftsForLesson(lessonId) {
 
 // -- Lesson messages (unified conversation per lesson) ------------------------
 
-export async function getLessonMessages(lessonId) {
-  const data = await fetchSyncData(`messages:${lessonId}`);
+export async function getLessonMessages(lessonId, options) {
+  const data = await fetchSyncData(`messages:${lessonId}`, options);
   return Array.isArray(data) ? data : [];
 }
 
-export async function saveLessonMessages(lessonId, msgs) {
+export async function saveLessonMessages(lessonId, msgs, { lessonSession } = {}) {
   const key = `messages:${lessonId}`;
-  let all = _cache.get(key);
-  if (!Array.isArray(all)) all = await getLessonMessages(lessonId);
-  const withTimestamps = msgs.map(m => ({ ...m, timestamp: m.timestamp || Date.now() }));
-  all = [...all, ...withTimestamps];
-  _cache.set(key, all);
-  await putSyncData(key, all);
+
+  if (!lessonSession) {
+    let all = _cache.get(key);
+    if (!Array.isArray(all)) all = await getLessonMessages(lessonId);
+    const withTimestamps = msgs.map((m) => ({ ...m, timestamp: m.timestamp || Date.now() }));
+    all = [...all, ...withTimestamps];
+    _cache.set(key, all);
+    await putSyncData(key, all);
+    return all;
+  }
+
+  const prepared = decorateLessonMessages(
+    msgs.map((message) => ({ ...message, timestamp: message.timestamp || Date.now() })),
+    lessonSession
+  );
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const current = await fetchSyncItem(key, { preferCache: attempt === 0 });
+    const existing = Array.isArray(current.data) ? current.data : [];
+    const merged = appendUniqueMessages(existing, prepared);
+    const result = await putSyncData(key, merged, {
+      version: current.version || 0,
+      guard: buildLessonGuard(lessonSession),
+      retryOnConflict: false,
+      optimistic: false,
+    });
+
+    if (result.ok) return merged;
+    if (result.conflict === 'version') continue;
+    if (result.conflict === 'stale_session') {
+      throw lessonSessionConflictError(lessonId, result.lessonSession);
+    }
+    throw new Error(`Failed to save lesson messages for ${lessonId}.`);
+  }
+
+  throw new SyncConflictError('Lesson messages stayed in conflict after multiple retries.', {
+    code: 'lesson_messages_conflict_exhausted',
+    conflict: 'version',
+    lessonId,
+  });
 }
 
 export async function clearLessonMessages(lessonId) {
@@ -339,6 +597,7 @@ export async function deletePreferences() {
 }
 
 export async function deleteLessonProgress(lessonId) {
+  await rotateLessonSession(lessonId);
   await deleteDraftsForLesson(lessonId);
   await deleteActivitiesForLesson(lessonId);
   await deleteActivityKBsForLesson(lessonId);

--- a/client/prompts/coach.md
+++ b/client/prompts/coach.md
@@ -16,6 +16,7 @@ Lessons are microlearning experiences designed to be completable in ~11 exchange
 You receive a JSON context as the first message containing:
 - `learnerName`: the learner's name — use it once in your first message, never again
 - `lessonName`, `lessonDescription`, `exemplar`: what this lesson is about and where it leads
+- `lessonStatus`: either `active` or `completed`
 - `objectives`: learning objectives with evidence definitions
 - `learnerProfile`: summary of who this learner is — their strengths, preferences, experience level, communication style. Use this to personalize your coaching.
 - `learnerPosition`: where the learner currently stands relative to the exemplar
@@ -23,6 +24,7 @@ You receive a JSON context as the first message containing:
 - `progress`: current progress score (0-10)
 - `activitiesCompleted`: number of exchanges so far
 - `pacingDirective` (optional): when present, this is a system-level instruction that overrides your normal coaching approach. Follow it exactly.
+- `postCompletionDirective` (optional): when present, the lesson is already complete. Follow it exactly.
 
 You also receive the program knowledge base and the conversation history.
 
@@ -90,6 +92,8 @@ You receive a list of all lessons in this classroom (appended at the end of this
 - Examples: "Now that you've wrapped this up — how did the lesson feel? Anything that clicked especially well, or parts that felt like a slog?" or "What would have made this more useful for you?"
 - If they share feedback, acknowledge it genuinely and probe deeper on anything specific. Their input helps improve the lesson.
 - Continue to include `[KB_UPDATE]` tags with their feedback captured in insights — this is valuable for lesson improvement.
+- Do NOT treat the same conversation as a new lesson. Never coach, assess, or award progress for another lesson inside a completed lesson thread.
+- If the learner wants to work on the next lesson, tell them plainly to start that lesson separately so their progress is tracked in the right place.
 
 ## Progress signal
 

--- a/client/src/lib/lessonEngine.js
+++ b/client/src/lib/lessonEngine.js
@@ -259,11 +259,13 @@ export async function resumeLesson(lessonId) {
 
 export function buildContext(lesson, lessonKB, profileSummary, learnerName) {
   const completed = lessonKB?.activitiesCompleted || 0;
+  const lessonStatus = lessonKB?.status === 'completed' ? 'completed' : 'active';
   const context = {
     learnerName: learnerName || '',
     lessonName: lesson.name,
     lessonDescription: lesson.description,
     exemplar: lesson.exemplar,
+    lessonStatus,
     objectives: lessonKB?.objectives || [],
     insights: lessonKB?.insights || [],
     learnerProfile: profileSummary || 'No profile yet',
@@ -271,6 +273,9 @@ export function buildContext(lesson, lessonKB, profileSummary, learnerName) {
     progress: lessonKB?.progress ?? 0,
     activitiesCompleted: completed,
   };
+  if (lessonStatus === 'completed') {
+    context.postCompletionDirective = 'This lesson is already complete. Stay in feedback mode only. Do not coach, assess, or award credit for another lesson in this conversation. If the learner wants to continue with a new lesson, tell them to start the next lesson separately so their work is tracked there.';
+  }
   // Pacing directives are nudges, not orders. The target (MAX_EXCHANGES) is a
   // design goal for ~20-minute lessons — never a deadline. The coach always
   // decides when the learner has demonstrated the exemplar. These messages

--- a/client/src/lib/lessonEngine.js
+++ b/client/src/lib/lessonEngine.js
@@ -9,7 +9,8 @@
 
 import {
   getLearnerProfileSummary, getPreferences,
-  getLessonKB, saveLessonKB,
+  ensureLessonSession,
+  getLessonKB, saveLessonKB, updateLessonKB,
   saveScreenshot,
   saveLessonMessages, getLessonMessages,
 } from '../../js/storage.js';
@@ -102,6 +103,7 @@ export function cleanStream(onStream) {
 export async function startLesson(lessonId, lesson, onStream) {
   await ensureProfileExists();
   const profileSummary = await getLearnerProfileSummary();
+  const lessonSession = await ensureLessonSession(lessonId);
 
   // Lesson Owner generates the KB
   const lessonKB = await orchestrator.initializeLessonKB(lesson, profileSummary);
@@ -109,7 +111,14 @@ export async function startLesson(lessonId, lesson, onStream) {
   lessonKB.name = lesson.name;
   lessonKB.progress = 0;
   lessonKB.startedAt = ts();
-  await saveLessonKB(lessonId, lessonKB);
+  try {
+    await saveLessonKB(lessonId, lessonKB, { lessonSession, retryOnConflict: false, optimistic: false });
+  } catch (error) {
+    if (error?.conflict === 'version') {
+      return resumeLesson(lessonId);
+    }
+    throw error;
+  }
   syncInBackground(`lessonKB:${lessonId}`);
 
   // Coach opens the conversation
@@ -125,15 +134,19 @@ export async function startLesson(lessonId, lesson, onStream) {
   const { text, progress, kbUpdate } = parseCoachResponse(coachMsg);
 
   if (progress != null) {
-    lessonKB.progress = progress;
-    await saveLessonKB(lessonId, lessonKB);
+    const updated = await updateLessonKB(
+      lessonId,
+      (currentLessonKB) => ({ ...(currentLessonKB || lessonKB), progress }),
+      { lessonSession, preferCache: false }
+    );
+    Object.assign(lessonKB, updated.lessonKB);
   }
 
   const messages = [
     { role: 'assistant', content: text, msgType: MSG_TYPES.GUIDE, phase: LESSON_PHASES.LEARNING, timestamp: ts() },
   ];
 
-  await saveLessonMessages(lessonId, messages);
+  await saveLessonMessages(lessonId, messages, { lessonSession });
   syncInBackground(`lessonKB:${lessonId}`, `messages:${lessonId}`);
   return { messages, lessonKB, phase: LESSON_PHASES.LEARNING };
 }
@@ -142,7 +155,11 @@ export async function startLesson(lessonId, lesson, onStream) {
  * Send a message in the lesson conversation.
  */
 export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream) {
-  let lessonKB = await getLessonKB(lessonId);
+  const lessonSession = await ensureLessonSession(lessonId);
+  let lessonKB = await getLessonKB(lessonId, { preferCache: false });
+  if (!lessonKB) {
+    throw new Error('Lesson progress was reset or is unavailable. Reload the lesson and try again.');
+  }
   const profileSummary = await getLearnerProfileSummary();
 
   // Save image if provided
@@ -153,7 +170,7 @@ export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream
   }
 
   // Build conversation tail — filter out messages with empty content (e.g. image-only)
-  const allMsgs = await getLessonMessages(lessonId);
+  const allMsgs = await getLessonMessages(lessonId, { preferCache: false });
   const tail = allMsgs.slice(-15)
     .map(m => ({ role: m.role, content: m.content }))
     .filter(m => m.content && (typeof m.content === 'string' ? m.content.trim() : m.content.length));
@@ -185,37 +202,18 @@ export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream
 
   const parsed = parseCoachResponse(coachMsg);
 
-  // Update lesson KB
-  if (parsed.kbUpdate) {
-    if (parsed.kbUpdate.insights?.length) {
-      lessonKB.insights = [...(lessonKB.insights || []), ...parsed.kbUpdate.insights];
-      // Prune old insights (keep last 10)
-      if (lessonKB.insights.length > 10) {
-        const older = lessonKB.insights.slice(0, lessonKB.insights.length - 10);
-        lessonKB.insights = [`[Earlier: ${older.join('; ')}]`, ...lessonKB.insights.slice(-10)];
-      }
-    }
-    if (parsed.kbUpdate.learnerPosition) {
-      lessonKB.learnerPosition = parsed.kbUpdate.learnerPosition;
-    }
-  }
-  if (parsed.progress != null) {
-    lessonKB.progress = parsed.progress;
-  }
-  lessonKB.activitiesCompleted = (lessonKB.activitiesCompleted || 0) + 1;
+  let applied = null;
+  const updated = await updateLessonKB(
+    lessonId,
+    (currentLessonKB) => {
+      applied = applyCoachResponseToKB(currentLessonKB || lessonKB, parsed, { now: ts });
+      return applied.lessonKB;
+    },
+    { lessonSession, preferCache: false }
+  );
+  lessonKB = updated.lessonKB;
+  const { achieved, phase } = applied;
 
-  // Completion is decided by the coach (progress 10). The system never
-  // force-completes a lesson on exchange count — learners should be moved
-  // toward the exemplar, not cut off mid-conversation. The pacing directives
-  // fed to the coach escalate the nudge over time, but the coach always
-  // chooses when to award progress 10.
-  const achieved = parsed.progress >= 10;
-  if (achieved && lessonKB.status !== 'completed') {
-    lessonKB.status = 'completed';
-    lessonKB.completedAt = ts();
-  }
-
-  await saveLessonKB(lessonId, lessonKB);
   syncInBackground(`lessonKB:${lessonId}`);
 
   // Profile updates — from explicit tag or from KB insights as fallback
@@ -232,30 +230,68 @@ export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream
 
   // Save messages
   const newMessages = [
-    { role: 'user', content: text || (imageKey ? '[image]' : ''), msgType: MSG_TYPES.USER, phase: LESSON_PHASES.LEARNING,
+    { role: 'user', content: text || (imageKey ? '[image]' : ''), msgType: MSG_TYPES.USER, phase,
       metadata: imageKey ? { imageKey } : null, timestamp: ts() },
-    { role: 'assistant', content: parsed.text, msgType: MSG_TYPES.GUIDE,
-      phase: achieved ? LESSON_PHASES.COMPLETED : LESSON_PHASES.LEARNING, timestamp: ts() },
+    { role: 'assistant', content: parsed.text, msgType: MSG_TYPES.GUIDE, phase, timestamp: ts() },
   ];
 
-  await saveLessonMessages(lessonId, newMessages);
+  await saveLessonMessages(lessonId, newMessages, { lessonSession });
   syncInBackground(`messages:${lessonId}`);
 
-  return { messages: newMessages, progress: parsed.progress, achieved, phase: achieved ? LESSON_PHASES.COMPLETED : LESSON_PHASES.LEARNING };
+  return { messages: newMessages, progress: parsed.progress, achieved, phase };
 }
 
 /**
  * Resume an existing lesson. Loads messages and KB.
  */
 export async function resumeLesson(lessonId) {
-  const messages = await getLessonMessages(lessonId);
-  const lessonKB = await getLessonKB(lessonId);
+  const messages = await getLessonMessages(lessonId, { preferCache: false });
+  const lessonKB = await getLessonKB(lessonId, { preferCache: false });
   const progress = lessonKB?.progress ?? 0;
   const phase = lessonKB?.status === 'completed' ? LESSON_PHASES.COMPLETED : LESSON_PHASES.LEARNING;
   return { messages, lessonKB, progress, phase };
 }
 
 // -- Helpers ------------------------------------------------------------------
+
+/**
+ * Apply a parsed coach response to a lesson KB. Pure — returns a new KB
+ * without mutating the input. Centralizes the "feedback mode" invariant:
+ * once a lesson is completed, the exchange counter freezes and `achieved`
+ * can't re-fire, so one-shot side effects (confetti, completion profile
+ * update) stay one-shot across the feedback conversation that follows.
+ */
+export function applyCoachResponseToKB(prevKB, parsed, { now = Date.now } = {}) {
+  const wasCompleted = prevKB?.status === 'completed';
+  const next = { ...prevKB };
+
+  if (parsed.kbUpdate) {
+    if (parsed.kbUpdate.insights?.length) {
+      next.insights = [...(next.insights || []), ...parsed.kbUpdate.insights];
+      if (next.insights.length > 10) {
+        const older = next.insights.slice(0, next.insights.length - 10);
+        next.insights = [`[Earlier: ${older.join('; ')}]`, ...next.insights.slice(-10)];
+      }
+    }
+    if (parsed.kbUpdate.learnerPosition) {
+      next.learnerPosition = parsed.kbUpdate.learnerPosition;
+    }
+  }
+  if (parsed.progress != null) {
+    next.progress = parsed.progress;
+  }
+  if (!wasCompleted) {
+    next.activitiesCompleted = (next.activitiesCompleted || 0) + 1;
+  }
+
+  const achieved = parsed.progress >= 10 && !wasCompleted;
+  if (achieved) {
+    next.status = 'completed';
+    next.completedAt = now();
+  }
+  const phase = next.status === 'completed' ? LESSON_PHASES.COMPLETED : LESSON_PHASES.LEARNING;
+  return { lessonKB: next, achieved, phase };
+}
 
 export function buildContext(lesson, lessonKB, profileSummary, learnerName) {
   const completed = lessonKB?.activitiesCompleted || 0;
@@ -275,29 +311,25 @@ export function buildContext(lesson, lessonKB, profileSummary, learnerName) {
   };
   if (lessonStatus === 'completed') {
     context.postCompletionDirective = 'This lesson is already complete. Stay in feedback mode only. Do not coach, assess, or award credit for another lesson in this conversation. If the learner wants to continue with a new lesson, tell them to start the next lesson separately so their work is tracked there.';
-  }
-  // Pacing directives are nudges, not orders. The target (MAX_EXCHANGES) is a
-  // design goal for ~20-minute lessons — never a deadline. The coach always
-  // decides when the learner has demonstrated the exemplar. These messages
-  // help the coach sharpen its focus as exchanges accumulate, but NEVER tell
-  // it to force-close a lesson on the learner.
-  const over = completed - MAX_EXCHANGES;
-  if (over >= 9) {
-    // 20+ exchanges: the lesson has run well past the target. Likely a sign
-    // the lesson design or the learner's starting point mismatched — worth
-    // a reflective note, but still the coach's call to close.
-    context.pacingDirective = 'This lesson has run well past its target length. If the learner has demonstrated the exemplar (or something close to it), this is a good moment to award progress 10 and close warmly. If they are still genuinely working toward it, keep moving them forward — prefer smaller, more concrete steps. Note in [KB_UPDATE] if the lesson design seems to be the issue.';
-  } else if (over >= 4) {
-    // 15+ exchanges: converge hard. Prefer closing when the exemplar is met,
-    // but do not force the issue if the learner is still making progress.
-    context.pacingDirective = 'The lesson has run longer than target. Compress: focus on the single biggest remaining gap. If the learner has demonstrated the exemplar, award progress 10 and close warmly. If they are close, one sharp final step can get them there. Keep moving them forward — never cut them off mid-thought.';
-  } else if (over >= 0) {
-    // 11+ exchanges: target reached. Start to converge.
-    context.pacingDirective = 'Target exchange count reached. Begin converging toward the exemplar — avoid introducing new objectives. If the learner has demonstrated the exemplar, award progress 10. Otherwise give one focused nudge that narrows the gap.';
-  } else if (completed >= MAX_EXCHANGES - 3) {
-    // 8-10 exchanges: pre-target — start converging.
-    const remaining = MAX_EXCHANGES - completed;
-    context.pacingDirective = `Approaching target (${remaining} exchange${remaining === 1 ? '' : 's'} until the ~20-minute design goal). Converge toward the exemplar — one focused task that narrows the gap. You may still introduce new concepts if the learner genuinely needs them to advance.`;
+  } else {
+    // Pacing directives are nudges, not orders. The target (MAX_EXCHANGES) is a
+    // design goal for ~20-minute lessons — never a deadline. The coach always
+    // decides when the learner has demonstrated the exemplar. These messages
+    // help the coach sharpen its focus as exchanges accumulate, but NEVER tell
+    // it to force-close a lesson on the learner. Skipped once the lesson is
+    // complete — the post-completion thread is feedback-only, and pacing
+    // nudges would conflict with postCompletionDirective.
+    const over = completed - MAX_EXCHANGES;
+    if (over >= 9) {
+      context.pacingDirective = 'This lesson has run well past its target length. If the learner has demonstrated the exemplar (or something close to it), this is a good moment to award progress 10 and close warmly. If they are still genuinely working toward it, keep moving them forward — prefer smaller, more concrete steps. Note in [KB_UPDATE] if the lesson design seems to be the issue.';
+    } else if (over >= 4) {
+      context.pacingDirective = 'The lesson has run longer than target. Compress: focus on the single biggest remaining gap. If the learner has demonstrated the exemplar, award progress 10 and close warmly. If they are close, one sharp final step can get them there. Keep moving them forward — never cut them off mid-thought.';
+    } else if (over >= 0) {
+      context.pacingDirective = 'Target exchange count reached. Begin converging toward the exemplar — avoid introducing new objectives. If the learner has demonstrated the exemplar, award progress 10. Otherwise give one focused nudge that narrows the gap.';
+    } else if (completed >= MAX_EXCHANGES - 3) {
+      const remaining = MAX_EXCHANGES - completed;
+      context.pacingDirective = `Approaching target (${remaining} exchange${remaining === 1 ? '' : 's'} until the ~20-minute design goal). Converge toward the exemplar — one focused task that narrows the gap. You may still introduce new concepts if the learner genuinely needs them to advance.`;
+    }
   }
   return JSON.stringify(context);
 }

--- a/client/src/pages/LessonChat.jsx
+++ b/client/src/pages/LessonChat.jsx
@@ -246,6 +246,9 @@ export default function LessonChat() {
   if (!state.loaded) return <div className="flex items-center justify-center py-12 text-muted-foreground" role="status" aria-live="polite">Loading...</div>;
   if (!lesson) return <p className="p-4 text-muted-foreground">Lesson not found.</p>;
   const busy = !!loading;
+  const composePlaceholder = phase === LESSON_PHASES.COMPLETED
+    ? 'Share feedback about this lesson...'
+    : 'Chat with your coach...';
 
   const renderMessage = (msg, idx) => {
     switch (msg.msgType) {
@@ -362,7 +365,7 @@ export default function LessonChat() {
       {phase && (
         <div ref={composeAnchorRef} aria-hidden={composePinned || undefined} className={composePinned ? 'invisible' : ''}>
           <ComposeBar
-            placeholder={phase === LESSON_PHASES.COMPLETED ? "Continue chatting..." : "Chat with your coach..."}
+            placeholder={composePlaceholder}
             onSend={handleSend}
             disabled={busy}
             allowImages
@@ -378,7 +381,7 @@ export default function LessonChat() {
       {phase && composePinned && (
         <div className="fixed bottom-9 left-0 right-0 z-50">
           <ComposeBar
-            placeholder={phase === LESSON_PHASES.COMPLETED ? "Continue chatting..." : "Chat with your coach..."}
+            placeholder={composePlaceholder}
             onSend={handleSend}
             disabled={busy}
             allowImages

--- a/client/tests/lesson-context.test.js
+++ b/client/tests/lesson-context.test.js
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildContext } from '../src/lib/lessonEngine.js';
+import { buildContext, applyCoachResponseToKB } from '../src/lib/lessonEngine.js';
+import { LESSON_PHASES } from '../src/lib/constants.js';
 
 function sampleLesson() {
   return {
@@ -49,5 +50,131 @@ describe('buildContext', () => {
 
     assert.equal(context.lessonStatus, 'active');
     assert.equal(context.postCompletionDirective, undefined);
+  });
+
+  it('omits pacing directives for completed lessons even past target', () => {
+    const context = JSON.parse(buildContext(
+      sampleLesson(),
+      {
+        status: 'completed',
+        progress: 10,
+        activitiesCompleted: 25,
+      },
+      'Learner profile summary',
+      'Alex'
+    ));
+
+    assert.equal(context.pacingDirective, undefined);
+    assert.ok(context.postCompletionDirective);
+  });
+
+  it('still emits pacing directives for active lessons over target', () => {
+    const context = JSON.parse(buildContext(
+      sampleLesson(),
+      {
+        status: 'active',
+        progress: 6,
+        activitiesCompleted: 15,
+      },
+      'Learner profile summary',
+      'Alex'
+    ));
+
+    assert.ok(context.pacingDirective);
+    assert.equal(context.postCompletionDirective, undefined);
+  });
+});
+
+describe('applyCoachResponseToKB', () => {
+  const activeKB = () => ({
+    status: 'active',
+    progress: 7,
+    activitiesCompleted: 8,
+    insights: [],
+    learnerPosition: 'Making progress',
+  });
+
+  const completedKB = () => ({
+    status: 'completed',
+    progress: 10,
+    activitiesCompleted: 12,
+    completedAt: 1_600_000_000_000,
+    insights: [],
+    learnerPosition: 'Exemplar achieved',
+  });
+
+  it('transitions to completed and reports achieved on the completion turn', () => {
+    const result = applyCoachResponseToKB(
+      activeKB(),
+      { progress: 10, kbUpdate: null, profileUpdate: null },
+      { now: () => 1_700_000_000_000 }
+    );
+
+    assert.equal(result.achieved, true);
+    assert.equal(result.phase, LESSON_PHASES.COMPLETED);
+    assert.equal(result.lessonKB.status, 'completed');
+    assert.equal(result.lessonKB.completedAt, 1_700_000_000_000);
+    assert.equal(result.lessonKB.activitiesCompleted, 9);
+  });
+
+  it('does not re-fire achieved when sending another message after completion', () => {
+    const result = applyCoachResponseToKB(
+      completedKB(),
+      { progress: 10, kbUpdate: { insights: ['feedback noted'] }, profileUpdate: null },
+      { now: () => 1_700_000_000_000 }
+    );
+
+    assert.equal(result.achieved, false);
+    assert.equal(result.phase, LESSON_PHASES.COMPLETED);
+    assert.equal(result.lessonKB.status, 'completed');
+  });
+
+  it('freezes activitiesCompleted once the lesson is complete', () => {
+    const prev = completedKB();
+    const result = applyCoachResponseToKB(
+      prev,
+      { progress: 10, kbUpdate: null, profileUpdate: null },
+      { now: () => 1_700_000_000_000 }
+    );
+
+    assert.equal(result.lessonKB.activitiesCompleted, prev.activitiesCompleted);
+  });
+
+  it('keeps completedAt from the original completion turn', () => {
+    const prev = completedKB();
+    const originalCompletedAt = prev.completedAt;
+    const result = applyCoachResponseToKB(
+      prev,
+      { progress: 9, kbUpdate: null, profileUpdate: null },
+      { now: () => 1_700_000_000_000 }
+    );
+
+    assert.equal(result.lessonKB.completedAt, originalCompletedAt);
+    assert.equal(result.phase, LESSON_PHASES.COMPLETED);
+  });
+
+  it('returns LEARNING phase for active lessons below progress 10', () => {
+    const result = applyCoachResponseToKB(
+      activeKB(),
+      { progress: 6, kbUpdate: null, profileUpdate: null },
+      { now: () => 1_700_000_000_000 }
+    );
+
+    assert.equal(result.achieved, false);
+    assert.equal(result.phase, LESSON_PHASES.LEARNING);
+    assert.equal(result.lessonKB.status, 'active');
+    assert.equal(result.lessonKB.activitiesCompleted, 9);
+  });
+
+  it('does not mutate the input KB', () => {
+    const prev = completedKB();
+    const snapshot = JSON.parse(JSON.stringify(prev));
+    applyCoachResponseToKB(
+      prev,
+      { progress: 9, kbUpdate: { insights: ['new insight'], learnerPosition: 'updated' }, profileUpdate: null },
+      { now: () => 1_700_000_000_000 }
+    );
+
+    assert.deepEqual(prev, snapshot);
   });
 });

--- a/client/tests/lesson-context.test.js
+++ b/client/tests/lesson-context.test.js
@@ -1,0 +1,53 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildContext } from '../src/lib/lessonEngine.js';
+
+function sampleLesson() {
+  return {
+    lessonId: 'foundation-1',
+    name: 'Foundations 1: Professional Identity',
+    description: 'Build a clear professional identity statement.',
+    exemplar: 'A polished professional identity statement.',
+  };
+}
+
+describe('buildContext', () => {
+  it('switches completed lessons into feedback-only mode', () => {
+    const context = JSON.parse(buildContext(
+      sampleLesson(),
+      {
+        status: 'completed',
+        progress: 10,
+        activitiesCompleted: 12,
+      },
+      'Learner profile summary',
+      'Alex'
+    ));
+
+    assert.equal(context.lessonStatus, 'completed');
+    assert.match(
+      context.postCompletionDirective,
+      /feedback/i
+    );
+    assert.match(
+      context.postCompletionDirective,
+      /start the next lesson separately/i
+    );
+  });
+
+  it('does not add post-completion instructions while a lesson is still active', () => {
+    const context = JSON.parse(buildContext(
+      sampleLesson(),
+      {
+        status: 'active',
+        progress: 6,
+        activitiesCompleted: 8,
+      },
+      'Learner profile summary',
+      'Alex'
+    ));
+
+    assert.equal(context.lessonStatus, 'active');
+    assert.equal(context.postCompletionDirective, undefined);
+  });
+});

--- a/client/tests/lesson-session-storage.test.js
+++ b/client/tests/lesson-session-storage.test.js
@@ -1,0 +1,218 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+const _serverStore = new Map();
+const _serverVersions = new Map();
+
+function response(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  };
+}
+
+function guardedLessonId(key) {
+  if (key.startsWith('lessonKB:')) return key.slice('lessonKB:'.length);
+  if (key.startsWith('messages:')) {
+    const lessonId = key.slice('messages:'.length);
+    return lessonId.startsWith('create:') ? null : lessonId;
+  }
+  if (key.startsWith('activities:')) return key.slice('activities:'.length);
+  if (key.startsWith('activityKBs:')) return key.slice('activityKBs:'.length);
+  if (key.startsWith('drafts:')) return key.slice('drafts:'.length);
+  return null;
+}
+
+function currentLessonSession(lessonId) {
+  if (!lessonId) return null;
+  return _serverStore.get(`lessonSession:${lessonId}`) || null;
+}
+
+globalThis.fetch = async (url, opts) => {
+  const path = new URL(url, 'http://localhost').pathname;
+  const syncMatch = path.match(/^\/v1\/sync\/(.+)/);
+  if (!syncMatch) return response(404, {});
+
+  const key = decodeURIComponent(syncMatch[1]);
+
+  if (opts?.method === 'PUT') {
+    const body = JSON.parse(opts.body);
+    const lessonId = guardedLessonId(key);
+    if (lessonId) {
+      const session = currentLessonSession(lessonId);
+      const sessionVersion = _serverVersions.get(`lessonSession:${lessonId}`) || 0;
+      if (!body.guard?.lessonSessionId || !session || session.lessonSessionId !== body.guard.lessonSessionId) {
+        return response(409, {
+          error: 'Lesson session conflict',
+          conflict: 'stale_session',
+          serverVersion: sessionVersion,
+          lessonSession: session,
+        });
+      }
+    }
+
+    const currentVersion = _serverVersions.get(key) || 0;
+    if ((body.version || 0) !== currentVersion) {
+      return response(409, {
+        error: 'Version conflict',
+        conflict: 'version',
+        serverVersion: currentVersion,
+      });
+    }
+
+    const newVersion = currentVersion + 1;
+    _serverStore.set(key, body.data);
+    _serverVersions.set(key, newVersion);
+    return response(200, { version: newVersion, updatedAt: '2026-04-21T00:00:00.000Z' });
+  }
+
+  if (opts?.method === 'DELETE') {
+    _serverStore.delete(key);
+    _serverVersions.delete(key);
+    return response(200, { ok: true });
+  }
+
+  if (_serverStore.has(key)) {
+    return response(200, {
+      data: _serverStore.get(key),
+      version: _serverVersions.get(key) || 0,
+    });
+  }
+
+  return response(404, {});
+};
+
+globalThis.localStorage = {
+  _store: {},
+  getItem(k) { return this._store[k] ?? null; },
+  setItem(k, v) { this._store[k] = v; },
+  removeItem(k) { delete this._store[k]; },
+  clear() { this._store = {}; },
+};
+
+localStorage.setItem('plato_auth', JSON.stringify({
+  accessToken: 'test-token',
+  refreshToken: 'test-refresh',
+}));
+
+const {
+  clearCache,
+  deleteLessonProgress,
+  ensureLessonSession,
+  getLessonKB,
+  getLessonMessages,
+  getLessonSession,
+  saveLessonMessages,
+  updateLessonKB,
+} = await import('../js/storage.js');
+
+describe('lesson session storage', () => {
+  beforeEach(() => {
+    clearCache();
+    _serverStore.clear();
+    _serverVersions.clear();
+  });
+
+  it('rotates the lesson session on reset and rejects stale writes from an older session', async () => {
+    const lessonId = 'foundation-1';
+    const firstSession = await ensureLessonSession(lessonId);
+
+    await saveLessonMessages(lessonId, [
+      { role: 'assistant', content: 'First run' },
+    ], { lessonSession: firstSession });
+
+    await deleteLessonProgress(lessonId);
+
+    const secondSession = await getLessonSession(lessonId);
+    assert.notEqual(secondSession.lessonSessionId, firstSession.lessonSessionId);
+    assert.equal(secondSession.generation, firstSession.generation + 1);
+
+    await assert.rejects(
+      () => saveLessonMessages(lessonId, [{ role: 'assistant', content: 'stale tab replay' }], { lessonSession: firstSession }),
+      /lesson session/i
+    );
+
+    const messages = await getLessonMessages(lessonId, { preferCache: false });
+    assert.deepEqual(messages, []);
+  });
+
+  it('merges new lesson messages onto the latest server history after a version conflict', async () => {
+    const lessonId = 'foundation-1';
+    const session = await ensureLessonSession(lessonId);
+
+    await saveLessonMessages(lessonId, [
+      { role: 'assistant', content: 'First coach message' },
+    ], { lessonSession: session });
+
+    const existing = _serverStore.get(`messages:${lessonId}`);
+    _serverStore.set(`messages:${lessonId}`, [
+      ...existing,
+      {
+        role: 'user',
+        content: 'Reply from another tab',
+        timestamp: 2,
+        messageId: 'srv-msg-2',
+        lessonSessionId: session.lessonSessionId,
+        lessonSessionGeneration: session.generation,
+      },
+    ]);
+    _serverVersions.set(`messages:${lessonId}`, 2);
+
+    await saveLessonMessages(lessonId, [
+      { role: 'assistant', content: 'Current tab reply' },
+    ], { lessonSession: session });
+
+    const messages = await getLessonMessages(lessonId, { preferCache: false });
+    assert.equal(messages.length, 3);
+    assert.equal(messages[0].content, 'First coach message');
+    assert.equal(messages[1].content, 'Reply from another tab');
+    assert.equal(messages[2].content, 'Current tab reply');
+  });
+
+  it('reapplies a lesson KB update against the latest server state after a version conflict', async () => {
+    const lessonId = 'foundation-1';
+    const session = await ensureLessonSession(lessonId);
+
+    _serverStore.set(`lessonKB:${lessonId}`, {
+      status: 'active',
+      progress: 4,
+      activitiesCompleted: 4,
+      learnerPosition: 'Working',
+      insights: [],
+    });
+    _serverVersions.set(`lessonKB:${lessonId}`, 1);
+
+    const cached = await getLessonKB(lessonId);
+    assert.equal(cached.progress, 4);
+
+    _serverStore.set(`lessonKB:${lessonId}`, {
+      status: 'active',
+      progress: 9,
+      activitiesCompleted: 9,
+      learnerPosition: 'Nearly there',
+      insights: ['close'],
+    });
+    _serverVersions.set(`lessonKB:${lessonId}`, 2);
+
+    const result = await updateLessonKB(
+      lessonId,
+      (prev) => ({
+        ...prev,
+        status: 'completed',
+        progress: 10,
+        activitiesCompleted: (prev?.activitiesCompleted || 0) + 1,
+      }),
+      { lessonSession: session }
+    );
+
+    assert.equal(result.lessonKB.progress, 10);
+    assert.equal(result.lessonKB.status, 'completed');
+    assert.equal(result.lessonKB.activitiesCompleted, 10);
+
+    const saved = _serverStore.get(`lessonKB:${lessonId}`);
+    assert.equal(saved.progress, 10);
+    assert.equal(saved.activitiesCompleted, 10);
+    assert.equal(_serverVersions.get(`lessonKB:${lessonId}`), 3);
+  });
+});

--- a/server/src/lib/db-dynamodb.js
+++ b/server/src/lib/db-dynamodb.js
@@ -284,8 +284,10 @@ const db = {
       TableName: SYNC_DATA_TABLE,
       Item: { userId, dataKey, data, updatedAt: now, version: newVersion },
     };
-    if (expectedVersion) {
-      params.ConditionExpression = 'attribute_not_exists(version) OR version = :v';
+    if (expectedVersion === 0) {
+      params.ConditionExpression = 'attribute_not_exists(version)';
+    } else {
+      params.ConditionExpression = 'version = :v';
       params.ExpressionAttributeValues = { ':v': expectedVersion };
     }
     await doc.send(new PutCommand(params));

--- a/server/src/lib/db-sqlite.js
+++ b/server/src/lib/db-sqlite.js
@@ -281,15 +281,14 @@ const db = {
     const newVersion = (expectedVersion || 0) + 1;
     const jsonData = JSON.stringify(data);
 
-    if (expectedVersion) {
-      // Optimistic locking: only update if version matches or item doesn't exist
-      const existing = sqlite.prepare(
-        'SELECT version FROM sync_data WHERE userId = ? AND dataKey = ?'
-      ).get(userId, dataKey);
+    const existing = sqlite.prepare(
+      'SELECT version FROM sync_data WHERE userId = ? AND dataKey = ?'
+    ).get(userId, dataKey);
 
-      if (existing && existing.version !== expectedVersion) {
-        throw conditionalCheckFailed('Version mismatch');
-      }
+    if (expectedVersion === 0) {
+      if (existing) throw conditionalCheckFailed('Version mismatch');
+    } else if (!existing || existing.version !== expectedVersion) {
+      throw conditionalCheckFailed('Version mismatch');
     }
 
     sqlite.prepare(

--- a/server/src/routes/sync.js
+++ b/server/src/routes/sync.js
@@ -7,7 +7,7 @@ const sync = new Hono();
 sync.use('/v1/sync', authenticate);
 sync.use('/v1/sync/*', authenticate);
 
-const VALID_DATA_KEYS = /^(profile|profileSummary|preferences|work|progress:.+|lessonKB:.+|activities:.+|activityKBs:.+|drafts:.+|messages:.+|lessons:.+|onboardingComplete)$/;
+const VALID_DATA_KEYS = /^(profile|profileSummary|preferences|work|progress:.+|lessonKB:.+|lessonSession:.+|activities:.+|activityKBs:.+|drafts:.+|messages:.+|lessons:.+|onboardingComplete)$/;
 
 // Keep user record name in sync with extension preferences
 async function syncNameIfNeeded(userId, dataKey, data) {
@@ -18,6 +18,36 @@ async function syncNameIfNeeded(userId, dataKey, data) {
 
 function validateDataKey(dataKey) {
   return VALID_DATA_KEYS.test(dataKey);
+}
+
+function lessonScopedId(dataKey) {
+  if (dataKey.startsWith('lessonKB:')) return dataKey.slice('lessonKB:'.length);
+  if (dataKey.startsWith('activities:')) return dataKey.slice('activities:'.length);
+  if (dataKey.startsWith('activityKBs:')) return dataKey.slice('activityKBs:'.length);
+  if (dataKey.startsWith('drafts:')) return dataKey.slice('drafts:'.length);
+  if (dataKey.startsWith('messages:')) {
+    const lessonId = dataKey.slice('messages:'.length);
+    return lessonId.startsWith('create:') ? null : lessonId;
+  }
+  return null;
+}
+
+async function validateLessonSessionGuard(userId, dataKey, guard) {
+  const lessonId = lessonScopedId(dataKey);
+  if (!lessonId) return null;
+
+  const lessonSessionItem = await db.getSyncData(userId, `lessonSession:${lessonId}`);
+  const lessonSession = lessonSessionItem?.data || null;
+  if (!guard?.lessonSessionId || !lessonSession || lessonSession.lessonSessionId !== guard.lessonSessionId) {
+    return {
+      error: 'Lesson session conflict',
+      conflict: 'stale_session',
+      serverVersion: lessonSessionItem?.version || 0,
+      lessonSession,
+    };
+  }
+
+  return null;
 }
 
 // GET /v1/sync — get all synced data
@@ -70,6 +100,10 @@ sync.put('/v1/sync/batch', async (c) => {
     if (!validateDataKey(item.dataKey) || item.data === undefined) {
       return { dataKey: item.dataKey, status: 'error', error: 'Invalid item' };
     }
+    const lessonSessionConflict = await validateLessonSessionGuard(userId, item.dataKey, item.guard);
+    if (lessonSessionConflict) {
+      return { dataKey: item.dataKey, status: 'conflict', ...lessonSessionConflict };
+    }
     try {
       const result = await db.putSyncData(userId, item.dataKey, item.data, item.version || 0);
       await syncNameIfNeeded(userId, item.dataKey, item.data);
@@ -98,9 +132,14 @@ sync.put('/v1/sync/:dataKey', async (c) => {
     return c.json({ error: 'Invalid dataKey' }, 400);
   }
 
-  const { data, version } = await c.req.json();
+  const { data, version, guard } = await c.req.json();
   if (data === undefined) {
     return c.json({ error: 'data is required' }, 400);
+  }
+
+  const lessonSessionConflict = await validateLessonSessionGuard(userId, dataKey, guard);
+  if (lessonSessionConflict) {
+    return c.json(lessonSessionConflict, 409);
   }
 
   try {

--- a/server/tests/lib/db-sqlite.test.js
+++ b/server/tests/lib/db-sqlite.test.js
@@ -183,6 +183,22 @@ describe('db-sqlite', () => {
       );
     });
 
+    it('rejects create writes when the item already exists at version 0', async () => {
+      await assert.rejects(
+        () => db.putSyncData(userId, 'profile', { name: 'Overwrite' }, 0),
+        { name: 'ConditionalCheckFailedException' }
+      );
+    });
+
+    it('rejects updates when the item was deleted after the caller cached an older version', async () => {
+      await db.deleteSyncData(userId, 'profile');
+      await assert.rejects(
+        () => db.putSyncData(userId, 'profile', { name: 'Resurrected' }, 2),
+        { name: 'ConditionalCheckFailedException' }
+      );
+      await db.putSyncData(userId, 'profile', { name: 'Blake Updated' }, 0);
+    });
+
     it('gets all sync data for a user', async () => {
       await db.putSyncData(userId, 'preferences', { name: 'Test' }, 0);
       const all = await db.getAllSyncData(userId);

--- a/server/tests/routes/sync.test.js
+++ b/server/tests/routes/sync.test.js
@@ -75,6 +75,57 @@ describe('PUT /v1/sync/:dataKey', () => {
     const res = await authedReq(app, 'PUT', '/v1/sync/progress:basics-wordpress', { data: {}, version: 0 });
     assert.equal(res.status, 200);
   });
+
+  it('rejects stale lesson-session writes for lesson-scoped keys', async () => {
+    db.getSyncData = async (_userId, dataKey) => {
+      if (dataKey === 'lessonSession:foundation-1') {
+        return {
+          dataKey,
+          version: 7,
+          data: { lessonId: 'foundation-1', lessonSessionId: 'session-current', generation: 3 },
+        };
+      }
+      return null;
+    };
+
+    const app = new Hono();
+    app.route('/', sync);
+    const res = await authedReq(app, 'PUT', '/v1/sync/messages:foundation-1', {
+      data: [{ role: 'assistant', content: 'stale replay' }],
+      version: 2,
+      guard: { lessonSessionId: 'session-old' },
+    });
+
+    assert.equal(res.status, 409);
+    const result = await res.json();
+    assert.equal(result.conflict, 'stale_session');
+    assert.equal(result.lessonSession.lessonSessionId, 'session-current');
+    assert.equal(result.serverVersion, 7);
+  });
+
+  it('accepts a matching lesson-session guard for lesson-scoped keys', async () => {
+    db.getSyncData = async (_userId, dataKey) => {
+      if (dataKey === 'lessonSession:foundation-1') {
+        return {
+          dataKey,
+          version: 3,
+          data: { lessonId: 'foundation-1', lessonSessionId: 'session-current', generation: 2 },
+        };
+      }
+      return null;
+    };
+    db.putSyncData = async () => ({ version: 4, updatedAt: '2024-01-01T00:00:00Z' });
+
+    const app = new Hono();
+    app.route('/', sync);
+    const res = await authedReq(app, 'PUT', '/v1/sync/lessonKB:foundation-1', {
+      data: { status: 'active', progress: 5 },
+      version: 3,
+      guard: { lessonSessionId: 'session-current' },
+    });
+
+    assert.equal(res.status, 200);
+  });
 });
 
 describe('PUT /v1/sync/batch', () => {


### PR DESCRIPTION
## What changed
- keep completed lesson threads in feedback-only mode by adding explicit completion state to the coach context
- instruct the coach prompt not to coach, assess, or award progress for a different lesson inside a completed thread
- update the post-completion compose placeholder to make it clear the thread is for lesson feedback
- add regression coverage for completed-vs-active lesson context
- add per-lesson session generations in synced storage so resetting a lesson rotates its lineage and stale tabs cannot replay old Foundation state into the current thread
- reject stale lesson-scoped sync writes server-side when their `lessonSessionId` no longer matches the current lesson session
- tighten optimistic locking in sync storage so version `0` only creates missing rows and deleted lesson rows cannot be resurrected by stale clients
- reapply lesson KB updates against the latest server state on conflict and merge message appends onto the latest server history instead of overwriting it
- add client and server regression tests around stale-session rejection, reset rotation, and conflict recovery

## Why
A completed lesson thread stayed attached to the original `lessonId`, but the coach could keep talking as if the learner had moved into the next lesson. Separately, the sync path could let an older tab or stale cache overwrite newer lesson progress or even recreate a reset lesson. Both behaviors are bad for trust, but the second one is especially serious because student progress durability is non-negotiable.

## Root cause
The completion path marked the lesson complete for storage, but the ongoing chat context did not explicitly tell the coach that the thread was feedback-only. On the storage side, lesson-scoped sync data had no per-run session/generation guard, conflict retries reused stale payloads, and optimistic locking still allowed version `0` writes to overwrite existing rows.

## User impact
Completed lesson threads now stay in feedback mode and no longer imply that progress for a follow-on lesson or foundation can be tracked in the same chat. Resetting or continuing a lesson from another stale tab no longer resurrects old Foundation state, and lesson message / KB conflict recovery now preserves the newest server-side progress instead of replaying stale cached data over it.

Note: this changes `client/prompts/coach.md`, so existing installs will see it as a pending content update for admins.

## Validation
- `cd client && npm test -- tests/lesson-session-storage.test.js tests/lesson-context.test.js`
- `git diff --check`
- `node --check client/js/storage.js`
- `node --check client/src/lib/lessonEngine.js`
- `node --check server/src/routes/sync.js`
- `node --check server/src/lib/db-sqlite.js`
- `node --check server/src/lib/db-dynamodb.js`

## Follow-up risk
Lesson turns still persist `lessonKB` and `messages` as separate writes, so this is not yet a fully atomic server-side turn commit. This PR closes the stale-tab/reset-resurrection path, but a fully atomic lesson-turn persistence path is still worth doing next.