### PR TITLE
Add Created by column to Admin Lessons table

### DIFF
--- a/client/src/pages/admin/AdminLessons.jsx
+++ b/client/src/pages/admin/AdminLessons.jsx
@@ -187,6 +187,7 @@ export default function AdminLessons() {
           <TableHeader>
             <TableRow>
               <TableHead>Name</TableHead>
+              <TableHead>Created by</TableHead>
               <TableHead>Updated by</TableHead>
               <TableHead>Updated</TableHead>
               <TableHead><span className="sr-only">Actions</span></TableHead>
@@ -209,6 +210,7 @@ export default function AdminLessons() {
                       }
                     </span>
                   </TableCell>
+                  <TableCell className="text-muted-foreground">{c.createdByName || '\u2014'}</TableCell>
                   <TableCell className="text-muted-foreground">{c.updatedByName || '\u2014'}</TableCell>
                   <TableCell>{c.updatedAt ? new Date(c.updatedAt).toLocaleDateString() : '\u2014'}</TableCell>
                   <TableCell>
@@ -229,7 +231,7 @@ export default function AdminLessons() {
             })}
             {lessons.length === 0 && (
               <TableRow>
-                <TableCell colSpan={4} className="text-center py-6 text-muted-foreground">No lessons yet.</TableCell>
+                <TableCell colSpan={5} className="text-center py-6 text-muted-foreground">No lessons yet.</TableCell>
               </TableRow>
             )}
           </TableBody>


### PR DESCRIPTION
## Summary

- Adds a `Created by` column to Admin → Lessons, between `Name` and `Updated by`, so admins can see who authored each lesson.
- Pure UI change — `createdByName` is already populated on save (`server/src/routes/admin.js`) and returned by `GET /v1/admin/lessons` (line 393); it just wasn't rendered anywhere after #85 renamed the single name column to `Updated by`.
- Legacy rows that pre-date the `createdByName` field render as `—`.

## Test plan

- [ ] On `/plato/lessons`, confirm the table now shows 4 data columns: Name, Created by, Updated by, Updated.
- [ ] Existing lessons created before the field was added show `—` in Created by; lessons authored after show the admin's username or email.
- [ ] Empty state still spans the full row width ("No lessons yet.") — colSpan bumped from 4 to 5.
- [ ] Share modal, Edit, and Delete actions still work.

User impact: low. Admin-only visual change; no server, test, or data-model work touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)