### PR TITLE
Bump hono and add overrides to clear Dependabot alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+# Make Dependabot manifest detection explicit for the monorepo.
+# Security updates are enabled at the repo level (Settings → Code security);
+# this file does not turn them on or off — it just tells Dependabot exactly
+# where to look. We deliberately do not enable scheduled version updates;
+# routine bumps stay manual, security PRs come automatically.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /server
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0  # disables version-update PRs; security PRs are unaffected
+    groups:
+      server-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: /client
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0  # disables version-update PRs; security PRs are unaffected
+    groups:
+      client-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0  # disables version-update PRs; security PRs are unaffected

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.12",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
-      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -3812,9 +3812,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5109,9 +5109,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",

--- a/client/package.json
+++ b/client/package.json
@@ -30,5 +30,10 @@
     "shadcn": "^4.1.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
+  },
+  "overrides": {
+    "hono": "^4.12.14",
+    "@hono/node-server": "^1.19.13",
+    "postcss": "^8.5.10"
   }
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,11 +16,11 @@
         "@slack/web-api": "^7.15.0",
         "bcryptjs": "^2.4.3",
         "better-sqlite3": "^12.8.0",
-        "hono": "^4.6.0",
+        "hono": "^4.12.14",
         "jose": "^5.0.0"
       },
       "devDependencies": {
-        "@hono/node-server": "^1.19.11"
+        "@hono/node-server": "^1.19.13"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -976,9 +976,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -987,6 +987,18 @@
       "peerDependencies": {
         "hono": "^4"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@slack/logger": {
       "version": "4.0.1",
@@ -1722,9 +1734,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -1994,9 +2006,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "funding": [
         {
           "type": "github",
@@ -2005,9 +2017,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -2020,9 +2033,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -2165,9 +2178,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/server/package.json
+++ b/server/package.json
@@ -19,10 +19,15 @@
     "@slack/web-api": "^7.15.0",
     "bcryptjs": "^2.4.3",
     "better-sqlite3": "^12.8.0",
-    "hono": "^4.6.0",
+    "hono": "^4.12.14",
     "jose": "^5.0.0"
   },
   "devDependencies": {
-    "@hono/node-server": "^1.19.11"
+    "@hono/node-server": "^1.19.13"
+  },
+  "overrides": {
+    "axios": "^1.15.0",
+    "follow-redirects": "^1.16.0",
+    "fast-xml-parser": "^5.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- Direct bumps: `server` `hono ^4.6.0 -> ^4.12.14` (covers 6 hono CVEs) and `@hono/node-server ^1.19.11 -> ^1.19.13`.
- Transitive vulns resolved via `npm overrides`:
  - `server`: `axios ^1.15.0`, `follow-redirects ^1.16.0`, `fast-xml-parser ^5.7.0` (came in via `@slack/web-api` and `@aws-sdk/*`).
  - `client`: `hono ^4.12.14`, `@hono/node-server ^1.19.13`, `postcss ^8.5.10` (came in via `shadcn -> @modelcontextprotocol/sdk` and `vite`).
- Add `.github/dependabot.yml` so Dependabot's manifest detection is explicit for the monorepo. Covers `/server` + `/client` npm and `/.github` github-actions; groups bumps per ecosystem; `open-pull-requests-limit: 0` disables scheduled version updates while leaving security PRs intact (security updates ignore that limit).
- `npm audit` reports `0 vulnerabilities` in both workspaces; `npm test` and `npm run build` clean.

## Reachability for plato
None of these CVEs are exploitable in plato's deployed surface:
- Cookie-related hono CVEs — plato uses JWT in \`localStorage\`, no cookies.
- \`serveStatic\` / \`toSSG\` / \`hono/jsx\` SSR / \`ipRestriction\` — plato runs as Lambda + API Gateway, none of those features in use.
- axios SSRF / metadata exfiltration — plato's axios calls hit fixed Bedrock/Anthropic endpoints, no user-controlled URLs or headers.
- \`postcss\` XSS — build-time only; CSS input is author-controlled.
- \`fast-xml-parser\` — buried in AWS SDK response parsing, not user-input-driven.

Bumping is cheap and clears the badge. \`User impact: low.\`

## Test plan
- [x] \`cd server && npm test\` (133/133 pass)
- [x] \`cd client && npm test\` (35/35 pass)
- [x] \`cd client && npm run build\` (clean)
- [x] \`npm audit\` in both workspaces (0 vulnerabilities)
- [ ] After merge, confirm Dependabot validates the new \`.github/dependabot.yml\` (Insights → Dependency graph → Dependabot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)