### PR TITLE
Bump code-review max-turns from 20 to 30

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -59,7 +59,7 @@ jobs:
           # races with the explicit `gh pr review` call in the prompt and
           # double-submits. See PR #73 (2026-04-17) where two reviews were
           # posted 6s apart with slightly different bodies.
-          claude_args: "--allowedTools Bash(*),Read(*),Glob,Grep --max-turns 20"
+          claude_args: "--allowedTools Bash(*),Read(*),Glob,Grep --max-turns 30"
           prompt: |
             You are a skeptical code reviewer. Your job is to find real problems the author missed.
             Read REVIEW.md and CLAUDE.md for project conventions.


### PR DESCRIPTION
## Summary
The Claude code-review agent has been silently no-op-ing on larger PRs by exhausting its turn budget reading the diff before reaching \`gh pr review\`. The verify guard catches it (working as designed), so the workflow fails loudly — but the underlying problem is that 20 turns isn't enough for a typical multi-file PR.

Observed:
- PR #115 (dependency overrides + dependabot.yml): 19/20 turns, no review posted
- PR #116 (ESLint setup, 30 files): 21 turns, no review posted

Bumping to 30 gives 50% more headroom without making the post-action verify a routine failure mode.

## ⚠️ This PR will fail its own Claude review

The \`claude-code-action\` self-modification guard refuses to run when the workflow file on a PR differs from main (security feature: prevents PRs from modifying their own reviewer). The required \`review\` status check will fail with a \`401 Unauthorized — Workflow validation failed\` error. This is documented expected behavior — admin-bypass merge is the intended path.

After merge, in-flight PRs (e.g. #116) can sync main back into their branch to pick up the new value, then re-run code-review.

\`User impact: none — affects only the CI reviewer.\`

## Test plan
- [ ] Admin-bypass merge (Claude review fails by design due to self-mod guard)
- [ ] Sync PR #116 with main; re-run code-review on #116; confirm it now completes within budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)