### PR TITLE
Add daily needs-info rescan as safety net for comment trigger

### DIFF
--- a/.github/workflows/needs-info-rescan.yml
+++ b/.github/workflows/needs-info-rescan.yml
@@ -1,0 +1,72 @@
+name: needs-info-rescan
+
+# Safety net for the issue-intake workflow's `issue_comment` trigger.
+#
+# The intake workflow re-runs on comments to `needs-info` issues so the
+# agent can flip the label to `ready-for-pilot` once the reporter has
+# answered. In practice, GitHub's `issue_comment` event delivery is not
+# 100% reliable — comments occasionally don't fire the workflow. This
+# scheduled scan catches anything that fell through.
+#
+# Runs weekday mornings before plato-pilot, so any issue flipped to
+# `ready-for-pilot` here becomes an available signal for the same day's
+# pilot run.
+
+on:
+  schedule:
+    - cron: '0 13 * * 0-4'   # 8:00 AM ET weekdays Sun–Thu (3h before pilot)
+  workflow_dispatch:
+
+jobs:
+  rescan:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      actions: write   # required to dispatch issue-intake.yml
+    steps:
+      - name: Dispatch intake on needs-info issues with new reporter replies
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # List open needs-info issues. For each, find the most recent
+          # claude[bot] comment timestamp and check whether any non-bot
+          # comment is newer. If yes, dispatch intake on that issue —
+          # the intake prompt's re-run guard handles the classification.
+          gh issue list \
+            --repo "${{ github.repository }}" \
+            --label needs-info \
+            --state open \
+            --json number \
+            --jq '.[].number' > /tmp/needs-info.txt
+
+          if [ ! -s /tmp/needs-info.txt ]; then
+            echo "No open needs-info issues. Nothing to do."
+            exit 0
+          fi
+
+          dispatched=0
+          while read -r n; do
+            [ -z "$n" ] && continue
+            # Compare timestamps as ISO strings — lexical compare works
+            # because they're zulu-format and same length.
+            stale=$(gh issue view "$n" \
+              --repo "${{ github.repository }}" \
+              --json comments \
+              --jq '
+                (.comments | map(select(.author.login == "claude")) | last | .createdAt // "1970-01-01T00:00:00Z") as $bot
+                | (.comments | map(select(.author.login != "claude" and (.createdAt > $bot))) | length > 0)
+              ')
+            if [ "$stale" = "true" ]; then
+              echo "Issue #$n has a reporter reply newer than claude[bot]'s last comment — dispatching intake."
+              gh workflow run issue-intake.yml \
+                --repo "${{ github.repository }}" \
+                -f issue_number="$n"
+              dispatched=$((dispatched + 1))
+            else
+              echo "Issue #$n: no new reporter reply since claude[bot] comment. Skipping."
+            fi
+          done < /tmp/needs-info.txt
+
+          echo "Dispatched intake on $dispatched issue(s)."


### PR DESCRIPTION
## Summary
The \`issue-intake\` workflow's \`issue_comment\` trigger (added in #114) is the primary path for re-classifying \`needs-info\` issues when the reporter replies. **In practice GitHub's \`issue_comment\` event delivery is not 100% reliable** — observed today: 5 needs-info issues with reporter replies (some over a week old) that never fired intake. The replies sat ignored until I dispatched the workflow manually.

This adds a scheduled workflow that runs every weekday morning (8 AM ET, 3h before pilot) and dispatches intake on any \`needs-info\` issue with a non-bot comment newer than the most recent \`claude[bot]\` comment. The intake prompt's existing re-run guard handles the rest — this workflow just finds candidates and triggers intake.

## Why a separate workflow (not a change to \`issue-intake.yml\`)
- The intake workflow is per-issue and event-driven. Adding a scan-and-dispatch mode would mix concerns and complicate the \`if:\` gate.
- This stays read-only on issues + dispatches the existing workflow → easy to reason about.
- If the comment trigger ever becomes reliable, this can be removed without touching intake.

## Behavior
- Runs Sun–Thu at 13:00 UTC (8 AM ET) to match plato-pilot's weekday cadence and complete before pilot picks signals.
- Manually triggerable via \`workflow_dispatch\` for ad-hoc rescans.
- For each open \`needs-info\` issue: compare the most recent \`claude[bot]\` comment timestamp against any newer non-bot comment. Dispatch intake when a newer reply exists.
- Cost: \`gh issue list\` + N \`gh issue view\` calls per run, then dispatches that internally trigger intake (which has its own cost). Bounded by the number of open \`needs-info\` issues — typically single digits.

\`User impact: none — workflow infra only.\`

## Test plan
- [ ] After merge, run \`gh workflow run needs-info-rescan.yml\` and confirm it lists current open needs-info issues correctly
- [ ] Confirm any issues with stale reporter replies get intake dispatched
- [ ] Tomorrow's scheduled run completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)