### PR TITLE
Reduce workflow LLM costs (Haiku swap + dependabot skip)

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -3,13 +3,21 @@ name: Code Review
 on:
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/dependabot.yml'
   issue_comment:
     types: [created]
 
 jobs:
   review:
+    # Skip dependabot PRs entirely — they're mechanical bumps already gated by
+    # the Lint job and don't need an AI review. Manual `@claude` mentions still
+    # work via the issue_comment branch if anyone wants a second look.
     if: |
-      (github.event_name == 'pull_request') ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.user.login != 'dependabot[bot]') ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/issue-intake.yml
+++ b/.github/workflows/issue-intake.yml
@@ -67,7 +67,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "claude"
           show_full_output: true
-          claude_args: "--allowedTools Bash(*),Read(*),Glob,Grep --max-turns 15"
+          # Haiku is plenty for classification: read issue, decide A/B/C, label, comment.
+          # Sonnet's reasoning headroom is wasted here — saves ~3x on per-run cost.
+          claude_args: "--allowedTools Bash(*),Read(*),Glob,Grep --max-turns 15 --model claude-haiku-4-5-20251001"
           prompt: |
             You are plato's issue-intake agent. Your job is to prepare new issues so
             plato-pilot (the daily autonomous engineering agent) or a human can act on

--- a/.github/workflows/revise.yml
+++ b/.github/workflows/revise.yml
@@ -48,7 +48,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: "claude"
           show_full_output: true
-          claude_args: "--allowedTools Bash(*),Read(*),Write(*),Edit,Glob,Grep --max-turns 30"
+          # Haiku handles mechanical fixup edits well — saves ~3x on per-run cost.
+          # If revise quality regresses on complex reviews, swap back to Sonnet.
+          claude_args: "--allowedTools Bash(*),Read(*),Write(*),Edit,Glob,Grep --max-turns 30 --model claude-haiku-4-5-20251001"
           prompt: |
             You are plato-pilot-revise. A code reviewer requested changes on PR #${{ env.PR_NUMBER }}.
             Address the review in ONE fixup commit. One shot — you do not get a second pass.


### PR DESCRIPTION
## Summary
Three changes that should cut monthly Claude spend ~30–40% without touching code-review quality:

1. **Switch \`issue-intake\` and \`revise\` to Haiku 4.5** (3× cheaper than Sonnet). Both are mechanical/classification tasks where Sonnet's reasoning headroom is wasted. Code-review stays on Sonnet — it's the quality-sensitive path that catches real bugs.
2. **Skip code-review on dependabot PRs.** They're mechanical bumps already gated by the Lint job; an AI review here is pure cost. Manual \`@claude\` mentions still trigger a review via the \`issue_comment\` branch.
3. **Skip code-review on docs-only PRs** (\`paths-ignore\` for \`**.md\`, \`docs/**\`, \`.github/dependabot.yml\`).

## ⚠️ Self-modification guard
This PR modifies three \`.github/workflows/*.yml\` files that use \`anthropics/claude-code-action@v1\`. The action's security check refuses to run when any of these workflow files differ from main. The required \`review\` status check will fail with \`401 Unauthorized — Workflow validation failed\`. **Admin-bypass merge is the intended path.**

\`User impact: low — affects CI economics only. Quality of code-review unchanged. Intake/revise quality should be equivalent for these task types but easy to revert if regressions appear.\`

## Test plan
- [ ] Admin-bypass merge (Claude review fails by design)
- [ ] Next dependabot PR confirms Code Review job is skipped
- [ ] Next issue/comment confirms intake still classifies correctly under Haiku
- [ ] Track week-over-week Claude API spend in console.anthropic.com to verify the savings

## Reverting
If intake or revise quality regresses, drop the \`--model claude-haiku-4-5-20251001\` flag from the \`claude_args\` line in either workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)