### PR TITLE
Fix intake prompt regression on Haiku (substitute literal issue number)

### DIFF
--- a/.github/workflows/issue-intake.yml
+++ b/.github/workflows/issue-intake.yml
@@ -71,9 +71,15 @@ jobs:
           # Sonnet's reasoning headroom is wasted here — saves ~3x on per-run cost.
           claude_args: "--allowedTools Bash(*),Read(*),Glob,Grep --max-turns 15 --model claude-haiku-4-5-20251001"
           prompt: |
-            You are plato's issue-intake agent. Your job is to prepare new issues so
-            plato-pilot (the daily autonomous engineering agent) or a human can act on
-            them without round-tripping for basic details.
+            You are plato's issue-intake agent triaging issue #${{ github.event.issue.number || inputs.issue_number }}.
+
+            Begin immediately. Do not ask the user for clarification or for the issue
+            number — issue #${{ github.event.issue.number || inputs.issue_number }} is
+            your assignment. Run the Step 1 commands below as your first action.
+
+            Your job is to prepare new issues so plato-pilot (the daily autonomous
+            engineering agent) or a human can act on them without round-tripping for
+            basic details.
 
             ## Context about plato-pilot
             plato-pilot triages open issues every weekday and may open a PR. It works
@@ -86,10 +92,10 @@ jobs:
             It struggles with vague reports ("something is broken", "can we make X better").
 
             ## Step 1: Read context (≤3 turns)
-            - `gh issue view $ISSUE_NUMBER --json title,body,labels,author,comments` — read the issue that triggered this run
+            - `gh issue view ${{ github.event.issue.number || inputs.issue_number }} --json title,body,labels,author,comments` — read the issue that triggered this run
             - Skim CLAUDE.md to understand the project
 
-            **Only work on `$ISSUE_NUMBER`** — do not scan other issues. The workflow
+            **Only work on `${{ github.event.issue.number || inputs.issue_number }}`** — do not scan other issues. The workflow
             fires per-issue; this run's job is one issue.
 
             ## Re-run guard (reopens, comment replies, and manual dispatches)
@@ -127,7 +133,7 @@ jobs:
               classification is obviously wrong.
 
             When switching labels, remove the old one first:
-            `gh issue edit $ISSUE_NUMBER --remove-label <old-label>` before adding the new.
+            `gh issue edit ${{ github.event.issue.number || inputs.issue_number }} --remove-label <old-label>` before adding the new.
 
             ## Step 2: Classify and act (1 pass, idempotent)
 
@@ -151,8 +157,8 @@ jobs:
             fuels pilot loops and wastes review cycles.
 
             ```
-            gh issue edit $ISSUE_NUMBER --add-label ready-for-pilot
-            gh issue comment $ISSUE_NUMBER --body "Thanks — this has enough detail for plato-pilot or a human to pick up. Tagged \`ready-for-pilot\`."
+            gh issue edit ${{ github.event.issue.number || inputs.issue_number }} --add-label ready-for-pilot
+            gh issue comment ${{ github.event.issue.number || inputs.issue_number }} --body "Thanks — this has enough detail for plato-pilot or a human to pick up. Tagged \`ready-for-pilot\`."
             ```
 
             **B. Needs info** — genuine but vague report. Vague feedback ("make it
@@ -165,14 +171,14 @@ jobs:
             comment` call — no retries, no follow-up edits.
 
             ```
-            gh issue comment $ISSUE_NUMBER --body "Thanks for opening this. A few details would help us act on it:
+            gh issue comment ${{ github.event.issue.number || inputs.issue_number }} --body "Thanks for opening this. A few details would help us act on it:
 
             1. <question>
             2. <question>
             3. <question>
 
             Reply here with what you can share and we'll pick this up."
-            gh issue edit $ISSUE_NUMBER --add-label needs-info
+            gh issue edit ${{ github.event.issue.number || inputs.issue_number }} --add-label needs-info
             ```
 
             **C. Spam or problematic** — close politely with a brief explanation and
@@ -186,8 +192,8 @@ jobs:
             are NOT spam — those go to B.
 
             ```
-            gh issue comment $ISSUE_NUMBER --body "Hey, this doesn't look like a plato bug or feature request, so we're closing it. If we got that wrong — if this is a real plato issue we misread — please reopen with a sentence or two about what you were doing in plato and we'll take another look."
-            gh issue close $ISSUE_NUMBER --reason "not planned"
+            gh issue comment ${{ github.event.issue.number || inputs.issue_number }} --body "Hey, this doesn't look like a plato bug or feature request, so we're closing it. If we got that wrong — if this is a real plato issue we misread — please reopen with a sentence or two about what you were doing in plato and we'll take another look."
+            gh issue close ${{ github.event.issue.number || inputs.issue_number }} --reason "not planned"
             ```
 
             Do not add a label when closing — the closed+comment state is the signal.
@@ -211,4 +217,4 @@ jobs:
               filters these out.
             - Don't lecture or offer design opinions. This is intake, not review.
             - Don't `@` anyone.
-            - Don't look at other issues; stick to `$ISSUE_NUMBER`.
+            - Don't look at other issues; stick to `${{ github.event.issue.number || inputs.issue_number }}`.


### PR DESCRIPTION
## Summary
Yesterday's Haiku swap in #120 regressed the intake workflow. Today's manual dispatch on issue #44 reproduced it: Haiku saw \`\$ISSUE_NUMBER\` in the prompt, didn't recognize it as a populated env var, and exited on turn 1 asking the user for an issue number — doing nothing. Sonnet was smart enough to interpret the indirection silently; Haiku reads the prompt more literally.

**Fix:** substitute \`\${{ github.event.issue.number || inputs.issue_number }}\` into the prompt at GitHub Actions template time, so the agent sees \`gh issue view 44 …\` directly — no env-var indirection to figure out. Also adds an explicit preamble: *"Begin immediately. Do not ask the user for clarification or for the issue number — issue #N is your assignment."*

The \`env: ISSUE_NUMBER\` block is left in place as harmless redundancy in case any tool calls expect it.

## ⚠️ Self-modification guard
This PR modifies \`.github/workflows/issue-intake.yml\` which uses \`anthropics/claude-code-action@v1\`. Required \`review\` check fails by design. **Admin-bypass merge.**

## Test plan
- [ ] Admin-bypass merge
- [ ] Re-dispatch intake on #44 (\`gh workflow run issue-intake.yml -f issue_number=44\`)
- [ ] Confirm the agent reads the issue, recognizes it as an epic, posts a comment, and switches the label to \`needs-decomposition\`
- [ ] Watch the next regular issue/comment-triggered intake run to confirm Haiku stays on track

\`User impact: low — affects intake workflow only.\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)