### PR TITLE
Fix "Plugin disabled" 404 from stale Lambda containers

### DIFF
--- a/docs/plugins/EXTENSION_REFERENCE.md
+++ b/docs/plugins/EXTENSION_REFERENCE.md
@@ -62,16 +62,22 @@ not pub-sub events.
 ### `onActivate(ctx)`
 
 Runs once when admin enables the plugin AND once at boot if the plugin is
-already enabled. Idempotent. Use for migrations, cache warmup, seeding. Don't
-run heavy work here — it's synchronous in the boot path.
+already enabled. May also run on a warm Lambda container the first time it
+notices another container flipped the plugin on (the dispatcher reconciles
+in-memory state with the persisted activation record before each plugin
+request). Treat it as effectively idempotent — use for migrations, cache
+warmup, seeding. Don't run heavy work here — it's synchronous in the request
+path.
 
 Errors are caught and logged as `plugin_on_activate_failed`; the plugin
 continues to run.
 
 ### `onDeactivate(ctx)`
 
-Runs when admin disables the plugin. Should release resources, NOT delete
-user data. Settings are preserved across disable/enable cycles.
+Runs when admin disables the plugin. May also run on a warm Lambda container
+the first time it notices another container flipped the plugin off, so this
+must also be idempotent. Should release resources, NOT delete user data.
+Settings are preserved across disable/enable cycles.
 
 Errors are caught and logged as `plugin_on_deactivate_failed`.
 

--- a/server/src/lib/plugins/dispatcher.js
+++ b/server/src/lib/plugins/dispatcher.js
@@ -19,10 +19,18 @@
  * Catch-all handler for `/v1/plugins/:pluginId/*`. Strips the prefix, dispatches
  * to the plugin's own Hono router via fetch(). The plugin's router applies its
  * own auth middleware.
+ *
+ * Calls `registry.refreshActivation` first so a Lambda container that booted
+ * before an enable/disable toggle picks up the persisted state instead of
+ * returning a stale "Plugin disabled" 404. `refreshActivation` is a no-op when
+ * the registry shim doesn't expose it (older test fakes).
  */
 export function makePluginDispatcher(registry) {
   return async (c) => {
     const pluginId = c.req.param('pluginId');
+    if (typeof registry.refreshActivation === 'function') {
+      await registry.refreshActivation(pluginId);
+    }
     const entry = registry.get(pluginId);
     if (!entry) return c.json({ error: 'Plugin not installed' }, 404);
     if (!entry.enabled) return c.json({ error: 'Plugin disabled' }, 404);
@@ -41,6 +49,9 @@ export function makePluginDispatcher(registry) {
  */
 export function makeSlackLegacyShim(registry) {
   return async (c) => {
+    if (typeof registry.refreshActivation === 'function') {
+      await registry.refreshActivation('slack');
+    }
     const entry = registry.get('slack');
     if (!entry?.enabled || !entry.serverModule?.routes) {
       return c.json({ error: 'Slack integration not available' }, 404);

--- a/server/src/lib/plugins/registry.js
+++ b/server/src/lib/plugins/registry.js
@@ -256,6 +256,60 @@ export const pluginRegistry = {
     return [...state.entries.values()];
   },
 
+  /**
+   * Re-read the activation record from DynamoDB and reconcile this container's
+   * in-memory entry with it. Fixes the cross-Lambda staleness where Container A
+   * handled the admin's enable-toggle (updating its own state + DB) while
+   * Container B — booted before the toggle — kept serving requests with
+   * `enabled: false` and returning "Plugin disabled" 404s from the dispatcher.
+   *
+   * Called by the dispatcher on every plugin route hit. Cheap (one GetItem)
+   * and plato's plugin traffic is low. If a flip is detected, hooks are
+   * (re)subscribed and onActivate/onDeactivate runs — same pattern as boot,
+   * which the contract already requires plugins to tolerate (lifecycle.js).
+   *
+   * No-op when there's no entry, the plugin failed to load, or the DB read
+   * fails — failures here must not knock the dispatcher offline.
+   */
+  async refreshActivation(id) {
+    const entry = state.entries.get(id);
+    if (!entry || !entry.manifest || entry.loadError) return entry;
+
+    let activation;
+    try {
+      activation = await readActivation();
+    } catch (err) {
+      logger.error('plugin_activation_refresh_failed', { pluginId: id, error: err?.message });
+      return entry;
+    }
+
+    const persisted = activation.record[id] || {};
+    const hasStoredState = id in activation.record;
+    const desiredEnabled = typeof persisted.enabled === 'boolean'
+      ? persisted.enabled
+      : Boolean(entry.manifest.defaultEnabled);
+    const desiredSettings = (persisted.settings && typeof persisted.settings === 'object')
+      ? persisted.settings
+      : {};
+
+    entry.settings = desiredSettings;
+    entry.hasStoredState = hasStoredState;
+
+    if (desiredEnabled === entry.enabled) return entry;
+
+    entry.enabled = desiredEnabled;
+    if (desiredEnabled) {
+      entry.hookUnsubs = subscribeHooks(id, entry.serverModule);
+      await invokeOnActivate(entry.serverModule, buildContext(id, entry.settings));
+    } else {
+      for (const unsub of entry.hookUnsubs) { try { unsub(); } catch { /* noop */ } }
+      entry.hookUnsubs = [];
+      await invokeOnDeactivate(entry.serverModule, buildContext(id, entry.settings));
+    }
+    logger.warn('plugin_activation_refreshed', { pluginId: id, enabled: desiredEnabled });
+    return entry;
+  },
+
   /** Toggle activation. Persists to sync-data and runs onActivate/onDeactivate. */
   async setEnabled(id, enabled) {
     const entry = state.entries.get(id);
@@ -264,8 +318,14 @@ export const pluginRegistry = {
     if (entry.enabled === enabled) return entry;
 
     const { record, version } = await readActivation();
-    record[id] = { ...(record[id] || {}), enabled, settings: entry.settings };
+    // Prefer freshly-read settings over local entry.settings — another Lambda
+    // container may have just updated settings and our in-memory copy is stale.
+    const persistedSettings = (record[id]?.settings && typeof record[id].settings === 'object')
+      ? record[id].settings
+      : entry.settings;
+    record[id] = { enabled, settings: persistedSettings };
     await writeActivation(record, version);
+    entry.settings = persistedSettings;
 
     entry.enabled = enabled;
     entry.hasStoredState = true;
@@ -318,9 +378,17 @@ export const pluginRegistry = {
       throw new Error('settings must be an object');
     }
     const { record, version } = await readActivation();
-    record[id] = { ...(record[id] || {}), enabled: entry.enabled, settings: nextSettings };
+    // Prefer the persisted enabled state over local entry.enabled — another
+    // Lambda container may have just toggled activation and this container's
+    // in-memory copy is stale. Without this guard, a settings save from a
+    // stale container would clobber a fresh enable back to disabled.
+    const persistedEnabled = typeof record[id]?.enabled === 'boolean'
+      ? record[id].enabled
+      : entry.enabled;
+    record[id] = { enabled: persistedEnabled, settings: nextSettings };
     await writeActivation(record, version);
     entry.settings = nextSettings;
+    entry.enabled = persistedEnabled;
     entry.hasStoredState = true;
     return entry;
   },
@@ -374,6 +442,12 @@ export const pluginRegistry = {
     state.pluginsDir = null;
     state.entries.clear();
     state.booted = false;
+  },
+
+  /** Test-only: inject a fully-formed entry. Does NOT touch DB. */
+  _setEntry(id, entry) {
+    state.entries.set(id, entry);
+    state.booted = true;
   },
 };
 

--- a/server/tests/lib/plugins/dispatcher.test.js
+++ b/server/tests/lib/plugins/dispatcher.test.js
@@ -91,6 +91,43 @@ describe('makePluginDispatcher (catch-all)', () => {
     // Inner router has no /admin/missing-route → Hono's default 404
     assert.equal(res.status, 404);
   });
+
+  it('calls refreshActivation before reading enabled (stale disabled → enabled flips)', async () => {
+    // Simulates the cross-Lambda staleness bug: this container booted with
+    // enabled=false; the admin enabled the plugin from another container, so
+    // refreshActivation flips this entry to enabled before the dispatcher
+    // makes its decision.
+    const routes = buildSlackLikeRouter();
+    const entry = {
+      manifest: { id: 'slack' },
+      enabled: false,
+      serverModule: { routes },
+    };
+    let refreshed = 0;
+    const reg = {
+      get: () => entry,
+      refreshActivation: async (id) => {
+        refreshed++;
+        if (id === 'slack') entry.enabled = true;
+      },
+    };
+    const app = appWith(makePluginDispatcher(reg));
+    const res = await app.request('/v1/plugins/slack/admin/users?q=alice');
+    assert.equal(refreshed, 1, 'refreshActivation should be called exactly once');
+    assert.equal(res.status, 200, 'request should succeed after the flip');
+  });
+
+  it('still returns "disabled" when refreshActivation confirms disabled', async () => {
+    const reg = {
+      get: () => ({ manifest: { id: 'slack' }, enabled: false, serverModule: { routes: buildSlackLikeRouter() } }),
+      refreshActivation: async () => { /* no-op: DB also says disabled */ },
+    };
+    const app = appWith(makePluginDispatcher(reg));
+    const res = await app.request('/v1/plugins/slack/admin/test');
+    assert.equal(res.status, 404);
+    const data = await res.json();
+    assert.match(data.error, /disabled/);
+  });
 });
 
 describe('makeSlackLegacyShim', () => {

--- a/server/tests/lib/plugins/registry-refresh.test.js
+++ b/server/tests/lib/plugins/registry-refresh.test.js
@@ -1,0 +1,185 @@
+/**
+ * Coverage for the cross-Lambda staleness fix:
+ *   - refreshActivation reconciles a stale in-memory entry with the persisted
+ *     activation record (the bug: warm container kept serving "Plugin disabled"
+ *     after admin enabled the plugin from a different container).
+ *   - updateSettings does not clobber a freshly-persisted enabled flag with a
+ *     stale local entry.enabled when called from a different container.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import db from '../../../src/lib/db.js';
+import { pluginRegistry } from '../../../src/lib/plugins/registry.js';
+
+const ACTIVATION_KEY = 'plugins:activation';
+
+function fakeSystemSyncStore() {
+  const store = new Map();
+  const k = (u, key) => `${u}\0${key}`;
+  return {
+    getSyncData: async (u, key) => store.get(k(u, key)) || null,
+    putSyncData: async (u, key, data, expectedVersion) => {
+      const cur = store.get(k(u, key));
+      const ver = cur?.version || 0;
+      if (expectedVersion && expectedVersion !== ver) {
+        const err = new Error('conflict'); err.name = 'ConditionalCheckFailedException'; throw err;
+      }
+      const next = { data, version: ver + 1, updatedAt: new Date().toISOString() };
+      store.set(k(u, key), next);
+      return next;
+    },
+    /** Directly seed an activation record (simulates write from another Lambda). */
+    seedActivation: (record) => {
+      const cur = store.get(k('_system', ACTIVATION_KEY));
+      const ver = cur?.version || 0;
+      store.set(k('_system', ACTIVATION_KEY), { data: record, version: ver + 1 });
+    },
+  };
+}
+
+function makeEntry({ id = 'demo', enabled = false, manifest, serverModule, settings = {} } = {}) {
+  return {
+    manifest: manifest || { id, defaultEnabled: false },
+    dir: `/tmp/plugins/${id}`,
+    serverModule: serverModule || { routes: { fetch: async () => new Response('ok') } },
+    enabled,
+    settings,
+    hasStoredState: false,
+    loadError: null,
+    hookUnsubs: [],
+  };
+}
+
+describe('pluginRegistry.refreshActivation', () => {
+  let store;
+  let originalGet;
+  let originalPut;
+
+  beforeEach(() => {
+    store = fakeSystemSyncStore();
+    originalGet = db.getSyncData;
+    originalPut = db.putSyncData;
+    db.getSyncData = store.getSyncData;
+    db.putSyncData = store.putSyncData;
+    pluginRegistry._reset();
+  });
+
+  afterEach(() => {
+    db.getSyncData = originalGet;
+    db.putSyncData = originalPut;
+    pluginRegistry._reset();
+  });
+
+  it('flips a stale disabled entry to enabled when DB has enabled=true', async () => {
+    let activated = 0;
+    const entry = makeEntry({
+      id: 'teacher-comments',
+      enabled: false,
+      serverModule: { onActivate: async () => { activated++; }, routes: {} },
+    });
+    pluginRegistry._setEntry('teacher-comments', entry);
+    store.seedActivation({ 'teacher-comments': { enabled: true, settings: {} } });
+
+    await pluginRegistry.refreshActivation('teacher-comments');
+
+    assert.equal(entry.enabled, true);
+    assert.equal(activated, 1, 'onActivate should run on the flip');
+  });
+
+  it('flips a stale enabled entry to disabled when DB has enabled=false', async () => {
+    let deactivated = 0;
+    const entry = makeEntry({
+      id: 'demo',
+      enabled: true,
+      serverModule: { onDeactivate: async () => { deactivated++; }, routes: {} },
+    });
+    pluginRegistry._setEntry('demo', entry);
+    store.seedActivation({ demo: { enabled: false, settings: {} } });
+
+    await pluginRegistry.refreshActivation('demo');
+
+    assert.equal(entry.enabled, false);
+    assert.equal(deactivated, 1, 'onDeactivate should run on the flip');
+  });
+
+  it('is a no-op when DB state matches local state (does not re-fire onActivate)', async () => {
+    let activated = 0;
+    const entry = makeEntry({
+      id: 'demo',
+      enabled: true,
+      serverModule: { onActivate: async () => { activated++; }, routes: {} },
+    });
+    pluginRegistry._setEntry('demo', entry);
+    store.seedActivation({ demo: { enabled: true, settings: { foo: 'bar' } } });
+
+    await pluginRegistry.refreshActivation('demo');
+
+    assert.equal(entry.enabled, true);
+    assert.equal(activated, 0, 'onActivate should not re-fire when state is unchanged');
+    assert.deepEqual(entry.settings, { foo: 'bar' }, 'settings still get refreshed');
+  });
+
+  it('falls back to manifest.defaultEnabled when no record exists', async () => {
+    const entry = makeEntry({
+      id: 'demo',
+      enabled: false,
+      manifest: { id: 'demo', defaultEnabled: true },
+      serverModule: { routes: {} },
+    });
+    pluginRegistry._setEntry('demo', entry);
+
+    await pluginRegistry.refreshActivation('demo');
+
+    assert.equal(entry.enabled, true);
+  });
+
+  it('is a safe no-op for unknown plugins, failed loads, and DB errors', async () => {
+    // Unknown id
+    await assert.doesNotReject(() => pluginRegistry.refreshActivation('nope'));
+    // Failed-load entry
+    pluginRegistry._setEntry('broken', { ...makeEntry({ id: 'broken' }), loadError: 'syntax' });
+    await assert.doesNotReject(() => pluginRegistry.refreshActivation('broken'));
+    // DB error
+    pluginRegistry._setEntry('demo', makeEntry({ id: 'demo' }));
+    db.getSyncData = async () => { throw new Error('boom'); };
+    await assert.doesNotReject(() => pluginRegistry.refreshActivation('demo'));
+  });
+});
+
+describe('pluginRegistry.updateSettings — stale-enabled write fix', () => {
+  let store;
+  let originalGet;
+  let originalPut;
+
+  beforeEach(() => {
+    store = fakeSystemSyncStore();
+    originalGet = db.getSyncData;
+    originalPut = db.putSyncData;
+    db.getSyncData = store.getSyncData;
+    db.putSyncData = store.putSyncData;
+    pluginRegistry._reset();
+  });
+
+  afterEach(() => {
+    db.getSyncData = originalGet;
+    db.putSyncData = originalPut;
+    pluginRegistry._reset();
+  });
+
+  it('does not clobber a DB-enabled flag from a stale (disabled) container', async () => {
+    // Container A enabled the plugin and persisted enabled=true.
+    store.seedActivation({ demo: { enabled: true, settings: { existing: 1 } } });
+    // Container B's local entry is still stale (enabled=false).
+    pluginRegistry._setEntry('demo', makeEntry({ id: 'demo', enabled: false }));
+
+    await pluginRegistry.updateSettings('demo', { newKey: 'v' });
+
+    const persisted = await db.getSyncData('_system', ACTIVATION_KEY);
+    assert.equal(persisted.data.demo.enabled, true, 'persisted enabled must stay true');
+    assert.deepEqual(persisted.data.demo.settings, { newKey: 'v' });
+
+    const entry = pluginRegistry.get('demo');
+    assert.equal(entry.enabled, true, 'local entry should also reconcile to true');
+  });
+});


### PR DESCRIPTION
## Summary

- `pluginRegistry` cached `entry.enabled` per Lambda container, only refreshed at boot. When admin enabled a plugin, only the container handling the PUT updated its in-memory state — other warm containers kept rejecting plugin requests with `Plugin disabled` even though DynamoDB and the admin UI showed the plugin as enabled. Reported live: enabling teacher-comments on prod, then immediately posting a teacher comment, returns 404 "Plugin disabled".
- Adds `pluginRegistry.refreshActivation(id)` that re-reads `_system:plugins:activation` and reconciles local state, running `onActivate`/`onDeactivate` on a flip. The dispatcher (and Slack legacy shim) call it before each plugin request.
- Also tightens `setEnabled` and `updateSettings` to prefer freshly-read fields over stale local ones — closes a latent race where a settings save from a stale container would clobber a fresh enable back to disabled.

## Why a per-request DB read is fine here

One `GetItem` on `_system:plugins:activation` per plugin route hit. Plugin traffic is low (admin-only routes for Slack and teacher-comments) so the cost is negligible vs. the alternatives (TTL'd cache, DynamoDB Streams). Failures are caught and the dispatcher falls back to existing in-memory state, so a transient DynamoDB blip can't knock plugin routes offline.

## Lifecycle contract change

`onActivate` and `onDeactivate` may now run on a warm container the first time it notices another container flipped activation. Both must remain idempotent — the contract already required this for boot, this just expands the surface. Documented in `docs/plugins/EXTENSION_REFERENCE.md`.

## Test plan

- [x] `cd server && npm test` — 235/235 passing
- [x] New `registry-refresh.test.js` (6 tests): flip-on, flip-off, no-op when matched, manifest.defaultEnabled fallback, safe-failure for unknown/load-failed/DB-error cases, and the `updateSettings` clobber fix
- [x] `dispatcher.test.js` (+2 tests): dispatcher calls `refreshActivation` and proceeds when stale entry flips to enabled; still returns `disabled` when refresh confirms disabled
- [ ] After deploy: enable teacher-comments on prod from one tab, post a comment from another tab — should land in DynamoDB without "Plugin disabled" 404 even on a different warm container

User impact: medium — fixes intermittent 404s on plugin admin actions (teacher comments, Slack invites) immediately after enabling a plugin. Pre-fix workaround was to wait ~10 min for stale containers to recycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)