### PR TITLE
Fix confirm-password field unreachable on iPhone signup

### DIFF
--- a/client/src/pages/Setup.jsx
+++ b/client/src/pages/Setup.jsx
@@ -55,7 +55,7 @@ export default function Setup() {
   }
 
   return (
-    <main className="min-h-dvh flex flex-col items-center justify-start py-12 p-4 overflow-y-auto" style={{ backgroundColor: '#470d99' }}>
+    <main className="min-h-dvh flex flex-col items-center justify-start py-12 p-4" style={{ backgroundColor: '#470d99' }}>
       <img src="/assets/logo-white.svg" alt="plato" className="h-10 mb-6" />
       <Card className="w-full max-w-md">
         <CardHeader>

--- a/client/src/pages/Signup.jsx
+++ b/client/src/pages/Signup.jsx
@@ -75,7 +75,7 @@ export default function Signup() {
   if (!branding) return null;
 
   return (
-    <main className="min-h-dvh flex flex-col items-center justify-start py-12 p-4 overflow-y-auto" style={{ backgroundColor: branding.primary }}>
+    <main className="min-h-dvh flex flex-col items-center justify-start py-12 p-4" style={{ backgroundColor: branding.primary }}>
       {branding.logo ? (<img src={branding.logo} alt={branding.classroomName} className="h-16 w-16 mb-6 rounded-lg object-contain" />) : (<h1 className="text-2xl font-bold text-white mb-6">{branding.classroomName}</h1>)}
       <Card className="w-full max-w-md">
         <CardHeader>


### PR DESCRIPTION
## Summary
- Removes `overflow-y-auto` from `<main>` on Signup and Setup pages so the document body scrolls naturally instead of an inner scroll container.
- iOS Safari unreliably touch-scrolls an `overflow-y-auto` flex child of a `min-h-dvh` parent (especially with the soft keyboard up), leaving the confirm-password field below the fold and unreachable on smaller iPhones.
- Brings these two pages in line with Login / ForgotPassword / ResetPassword, which already use plain `min-h-dvh` without an inner scroll.

## Reporter context
A signup invitee on iPhone reported they couldn't see the confirm-password field. Repro on iPhone SE-class viewports: the Card (header + name + username + optional group + password + confirm + submit + footer) is taller than the dynamic viewport, and the inner scroll on `<main>` failed to engage.

## Test plan
- [x] `cd server && npm test` — 227/227 pass
- [x] `cd client && npm run build` — clean
- [x] `cd client && npx eslint src/pages/Signup.jsx src/pages/Setup.jsx` — clean
- [ ] Manual: open `/signup?token=...` on a real iPhone, scroll to confirm-password field
- [ ] Manual: open `/setup` on iPhone, scroll to bottom of form
- [ ] Verify desktop signup still looks correct (top-aligned, `py-12` padding intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)