### PR TITLE
Add actionable guidance to over-target pacing warning card

### DIFF
--- a/client/src/pages/admin/AdminHome.jsx
+++ b/client/src/pages/admin/AdminHome.jsx
@@ -32,8 +32,13 @@ function PacingSection({ stats }) {
   // Flag when over-target lessons are running significantly long (≥15 exchanges)
   const overTargetWarning = avgExchangesOverTarget != null && avgExchangesOverTarget >= 15;
 
+  // Flag when a large fraction of completions are going over target (>25%)
+  const overTargetFraction = hasCompletions ? overTarget / totalCompletions : 0;
+  const overTargetFractionHigh = overTargetFraction > 0.25;
+
   let cardClasses = '';
   let signal = '';
+  let signalDetail = null;
   if (rate !== null) {
     if (rate >= 75) {
       cardClasses = 'border-green-300 bg-green-50 ring-2 ring-green-200';
@@ -41,9 +46,11 @@ function PacingSection({ stats }) {
     } else if (rate >= 50) {
       cardClasses = 'border-yellow-300 bg-yellow-50 ring-2 ring-yellow-200';
       signal = 'Some lessons are running long — review objectives or coach pacing';
+      signalDetail = 'Common causes: too many learning objectives, an exemplar that sets a very high bar, or a lesson topic that requires more scaffolding exchanges. Try simplifying objectives to 2–3 focused outcomes or tightening the exemplar scope.';
     } else {
       cardClasses = 'border-red-300 bg-red-50 ring-2 ring-red-200';
       signal = 'Most lessons exceed the target — simplify objectives or raise the target';
+      signalDetail = 'Most learners are taking significantly more exchanges than the target. Review your lessons for scope creep: each lesson should target one narrow skill. Consider splitting broad lessons into two focused ones.';
     }
   }
 
@@ -70,6 +77,9 @@ function PacingSection({ stats }) {
                 within {exchangeTarget} exchanges
               </div>
               <div className="text-sm font-semibold mt-1">{signal}</div>
+              {signalDetail && (
+                <div className="text-xs mt-2 text-muted-foreground">{signalDetail}</div>
+              )}
             </>
           ) : (
             <div className="text-sm text-muted-foreground mt-2">
@@ -101,12 +111,23 @@ function PacingSection({ stats }) {
             >
               Avg exchanges (over target)
             </div>
+            {overTargetWarning && (
+              <div className="text-xs mt-1 text-yellow-800">
+                Over-target lessons averaging {avgExchangesOverTarget} exchanges — review lesson objectives and exemplar scope in{' '}
+                <Link to="/plato/lessons" className="underline">Lessons</Link>.
+              </div>
+            )}
           </CardContent>
         </Card>
-        <Card className={overTarget > 0 ? 'border-yellow-300 bg-yellow-50 ring-2 ring-yellow-200' : ''}>
+        <Card className={overTargetFractionHigh ? 'border-yellow-300 bg-yellow-50 ring-2 ring-yellow-200' : (overTarget > 0 ? 'border-yellow-300 bg-yellow-50 ring-2 ring-yellow-200' : '')}>
           <CardContent>
             <div className="text-2xl font-bold">{overTarget}</div>
             <div className="text-sm text-muted-foreground">Went over target</div>
+            {overTargetFractionHigh && (
+              <div className="text-xs mt-1 text-yellow-800">
+                {Math.round(overTargetFraction * 100)}% of completions — consider reviewing lesson scope.
+              </div>
+            )}
           </CardContent>
         </Card>
         <Card>


### PR DESCRIPTION
## Motivation

Current KPI snapshot shows a yellow-zone on-target rate of 57% (159/279 completions), with 120 lessons going over target and `avgExchangesOverTarget` at 16.2 — above the 15-exchange warning threshold that already turns the card yellow. The admin dashboard surfaces the number but gives no guidance on *why* this happens or what to do about it, leaving admins without a clear path to remediation.

## Changes

- Added a contextual advisory message to the "Avg exchanges (over target)" card when `avgExchangesOverTarget >= 15`, explaining the likely cause (lesson design mismatch — too many objectives or a poorly-scoped exemplar) and linking to the Lessons admin page to review.
- Added a similar advisory to the on-target rate card in the yellow zone, suggesting specific remediation steps (review objectives, simplify exemplar, or check coach prompt pacing).
- Made the `overTarget` card advisory more specific: when over-target count is high as a fraction of total completions (>25%), surfaces a proportional signal rather than just the raw count.
- All changes are display-only, no data model or API changes.

---
*Proposed by [plato-pilot](https://github.com/UIC-OSF/plato-pilot) — automated KPI-driven suggestions*