### PR TITLE
Fix jq escaping in code-review prep step (unblocks all PR reviews)

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -107,7 +107,7 @@ jobs:
             echo
             echo "## PR metadata"
             gh pr view "$PR_NUMBER" --json number,title,author,body,baseRefName,headRefName \
-              --jq '"PR #\(.number): \(.title)\nAuthor: \(.author.login)\nBase: \(.baseRefName) ← Head: \(.headRefName)\n\n--- PR body ---\n\(.body // \"(no body)\")"'
+              --jq '"PR #\(.number): \(.title)\nAuthor: \(.author.login)\nBase: \(.baseRefName) ← Head: \(.headRefName)\n\n--- PR body ---\n\(.body // "(no body)")"'
             echo
           } >> "$CTX"
 


### PR DESCRIPTION
## Motivation

PR #146 shipped a bug. The `gh pr view ... --jq '...'` line in the new \"Build review context\" step used `\\\"(no body)\\\"` inside a jq interpolation. Inside `\\(...)` jq parses normal jq syntax — the backslashes there are not shell escapes, they're invalid jq tokens. The build-context step exits immediately with `failed to parse jq expression (line 1, column 134)`, which fails every Code Review run on main until it's fixed.

This blocks every other PR's `review` required check from passing.

## Fix

One-character class change: drop the `\\` from `\\\"(no body)\\\"` → `\"(no body)\"`. Inside `\\(.body // \"(no body)\")` the inner quotes are jq string delimiters; the surrounding shell single-quotes preserve them literally so no shell escaping is needed.

Verified locally:
```
$ echo '{...}' | jq -r '"...\\(.body // \"(no body)\")"'
PR #1: x
Author: a
...
```

## Test plan

- [ ] This PR's own auto-review run completes without crashing in the prep step
- [ ] `/tmp/review-context.md` includes the PR metadata block

## Risk

This unblocks CI. Without it, no future PR can pass the required `review` check, so this needs admin-bypass merge to land.

User impact: none — CI-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)