### PR TITLE
Raise coach maxTokens to 1024 to fix mid-response cutoff

### DIFF
--- a/client/src/lib/lessonEngine.js
+++ b/client/src/lib/lessonEngine.js
@@ -141,7 +141,7 @@ export async function startLesson(lessonId, lesson, onStream) {
     'coach',
     [{ role: 'user', content: context }, { role: 'assistant', content: 'Ready.' }, { role: 'user', content: 'Start the lesson.' }],
     cleanStream(onStream),
-    512
+    1024
   );
 
   const { text, progress } = parseCoachResponse(coachMsg);
@@ -202,7 +202,7 @@ export async function sendMessage(lessonId, lesson, text, imageDataUrl, onStream
     'coach',
     messages,
     cleanStream(onStream),
-    512
+    1024
   );
 
   const parsed = parseCoachResponse(coachMsg);


### PR DESCRIPTION
## Motivation

Coach responses include both the visible coaching text AND the structured tag section (`[PROGRESS:N]`, `[KB_UPDATE:{...}]`, `[PROFILE_UPDATE:{...}]`) appended at the end. On complex turns the combined length was hitting the 512 maxTokens limit and the response truncated mid-tag — `parseCoachResponse` would then fall back to nulls for `kbUpdate`/`profileUpdate` and KB/profile updates would silently stop landing.

1024 is roomy enough for typical responses + tags without encouraging the coach to ramble.

## Changes

Two literals in `client/src/lib/lessonEngine.js`: the maxTokens arg to `orchestrator.converseStream` in both `startLesson` (line 144) and `sendMessage` (line 205).

## Why this PR (and not #141)

This replaces #141, which was titled the same way but the bot bundled the maxTokens bump inside a complete `lessonEngine.js` rewrite that introduced multiple critical regressions:
- `resumeLesson` deleted but still called from `LessonChat.jsx` (runtime crash on resume)
- `updateProfileOnCompletionInBackground` called with wrong args (runtime crash on completion)
- `buildContext` missing 5 required coach context fields (`objectives`, `insights`, `learnerPosition`, `progress`, `lessonStatus`)
- `applyCoachResponseToKB` rewritten with new KB schema (incompatible with stored data)
- Pacing directives reworded to use "CRITICAL"/"URGENT" language (violates CLAUDE.md "never tell the coach to force-close")
- Per-turn message-history doubling

This PR is just the actual fix the title describes. #141 will be closed.

## Test plan

- [x] Lint clean (`cd client && npx eslint src/lib/lessonEngine.js`)
- [x] Server tests pass (`cd server && npm test` → 230 passing)
- [ ] Coach completes a complex lesson turn without mid-response cutoff (manual verify post-deploy)

User impact: medium — fixes silent KB/profile update loss on complex turns; no behavior change beyond the larger token budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)