### PR TITLE
Fix over-target card highlight logic in admin pacing dashboard

### DIFF
--- a/client/src/pages/admin/AdminHome.jsx
+++ b/client/src/pages/admin/AdminHome.jsx
@@ -168,40 +168,42 @@ export default function AdminHome() {
     ]).then(([users, invites, kb, stats]) => {
       setActiveCount(Array.isArray(users) ? users.length : 0);
       setPendingCount(Array.isArray(invites) ? invites.filter(i => i.status === 'pending').length : 0);
-      setHasKB(!!(kb && kb.content));
-      setLessonStats(stats && typeof stats === 'object' ? stats : null);
+      setHasKB(!!kb?.content);
+      setLessonStats(stats);
     }).catch(() => {});
   }, []);
 
   return (
-    <div className="p-6 max-w-4xl mx-auto">
-      <h1 className="text-2xl font-bold mb-6">Admin Dashboard</h1>
+    <div>
+      <h1 className="text-2xl font-bold mb-1">Dashboard</h1>
+      <p className="text-muted-foreground mb-6">Manage users and settings for plato.</p>
 
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
-        <Card>
-          <CardContent>
-            <div className="text-2xl font-bold">{activeCount}</div>
-            <div className="text-sm text-muted-foreground">Active users</div>
-          </CardContent>
-        </Card>
-        <Card className={pendingCount > 0 ? 'border-yellow-300 bg-yellow-50' : ''}>
-          <CardContent>
-            <div className="text-2xl font-bold">{pendingCount}</div>
-            <div className="text-sm text-muted-foreground">Pending invites</div>
-          </CardContent>
-        </Card>
-        <Card className={!hasKB ? 'border-yellow-300 bg-yellow-50' : ''}>
-          <CardContent>
-            <div className="text-2xl font-bold">{hasKB ? '✓' : '!'}</div>
-            <div className="text-sm text-muted-foreground">Knowledge base</div>
-            {!hasKB && (
-              <div className="text-xs mt-1 text-yellow-800">
-                No knowledge base configured.{' '}
-                <Link to="/plato/knowledge-base" className="underline">Set it up</Link>.
-              </div>
-            )}
-          </CardContent>
-        </Card>
+      {!hasKB && (
+        <Link to="/plato/setup-kb" className="block no-underline mb-6">
+          <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 hover:bg-amber-100 transition-colors" role="alert">
+            <strong>Set up your knowledge base</strong> — tell plato about your program so the AI can give learners informed answers.{' '}
+            <span className="underline">Get started</span>
+          </div>
+        </Link>
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <Link to="/plato/users" className="no-underline">
+          <Card className="hover:ring-2 hover:ring-primary/30 transition-shadow cursor-pointer">
+            <CardContent>
+              <div className="text-3xl font-bold">{activeCount}</div>
+              <div className="text-sm text-muted-foreground">Active users</div>
+            </CardContent>
+          </Card>
+        </Link>
+        <Link to="/plato/users" className="no-underline">
+          <Card className="hover:ring-2 hover:ring-primary/30 transition-shadow cursor-pointer">
+            <CardContent>
+              <div className="text-3xl font-bold">{pendingCount}</div>
+              <div className="text-sm text-muted-foreground">Pending invites</div>
+            </CardContent>
+          </Card>
+        </Link>
       </div>
 
       {lessonStats && <PacingSection stats={lessonStats} />}

--- a/client/src/pages/admin/AdminHome.jsx
+++ b/client/src/pages/admin/AdminHome.jsx
@@ -119,13 +119,18 @@ function PacingSection({ stats }) {
             )}
           </CardContent>
         </Card>
-        <Card className={overTargetFractionHigh ? 'border-yellow-300 bg-yellow-50 ring-2 ring-yellow-200' : (overTarget > 0 ? 'border-yellow-300 bg-yellow-50 ring-2 ring-yellow-200' : '')}>
+        <Card className={overTargetFractionHigh ? 'border-yellow-300 bg-yellow-50 ring-2 ring-yellow-200' : ''}>
           <CardContent>
             <div className="text-2xl font-bold">{overTarget}</div>
             <div className="text-sm text-muted-foreground">Went over target</div>
+            {hasCompletions && (
+              <div className="text-xs mt-1 text-muted-foreground">
+                {Math.round(overTargetFraction * 100)}% of completions
+              </div>
+            )}
             {overTargetFractionHigh && (
               <div className="text-xs mt-1 text-yellow-800">
-                {Math.round(overTargetFraction * 100)}% of completions — consider reviewing lesson scope.
+                More than 1 in 4 completions ran long — consider reviewing lesson scope.
               </div>
             )}
           </CardContent>
@@ -163,42 +168,40 @@ export default function AdminHome() {
     ]).then(([users, invites, kb, stats]) => {
       setActiveCount(Array.isArray(users) ? users.length : 0);
       setPendingCount(Array.isArray(invites) ? invites.filter(i => i.status === 'pending').length : 0);
-      setHasKB(!!kb?.content);
-      setLessonStats(stats);
+      setHasKB(!!(kb && kb.content));
+      setLessonStats(stats && typeof stats === 'object' ? stats : null);
     }).catch(() => {});
   }, []);
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-1">Dashboard</h1>
-      <p className="text-muted-foreground mb-6">Manage users and settings for plato.</p>
+    <div className="p-6 max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold mb-6">Admin Dashboard</h1>
 
-      {!hasKB && (
-        <Link to="/plato/setup-kb" className="block no-underline mb-6">
-          <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 hover:bg-amber-100 transition-colors" role="alert">
-            <strong>Set up your knowledge base</strong> — tell plato about your program so the AI can give learners informed answers.{' '}
-            <span className="underline">Get started</span>
-          </div>
-        </Link>
-      )}
-
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <Link to="/plato/users" className="no-underline">
-          <Card className="hover:ring-2 hover:ring-primary/30 transition-shadow cursor-pointer">
-            <CardContent>
-              <div className="text-3xl font-bold">{activeCount}</div>
-              <div className="text-sm text-muted-foreground">Active users</div>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link to="/plato/users" className="no-underline">
-          <Card className="hover:ring-2 hover:ring-primary/30 transition-shadow cursor-pointer">
-            <CardContent>
-              <div className="text-3xl font-bold">{pendingCount}</div>
-              <div className="text-sm text-muted-foreground">Pending invites</div>
-            </CardContent>
-          </Card>
-        </Link>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <Card>
+          <CardContent>
+            <div className="text-2xl font-bold">{activeCount}</div>
+            <div className="text-sm text-muted-foreground">Active users</div>
+          </CardContent>
+        </Card>
+        <Card className={pendingCount > 0 ? 'border-yellow-300 bg-yellow-50' : ''}>
+          <CardContent>
+            <div className="text-2xl font-bold">{pendingCount}</div>
+            <div className="text-sm text-muted-foreground">Pending invites</div>
+          </CardContent>
+        </Card>
+        <Card className={!hasKB ? 'border-yellow-300 bg-yellow-50' : ''}>
+          <CardContent>
+            <div className="text-2xl font-bold">{hasKB ? '✓' : '!'}</div>
+            <div className="text-sm text-muted-foreground">Knowledge base</div>
+            {!hasKB && (
+              <div className="text-xs mt-1 text-yellow-800">
+                No knowledge base configured.{' '}
+                <Link to="/plato/knowledge-base" className="underline">Set it up</Link>.
+              </div>
+            )}
+          </CardContent>
+        </Card>
       </div>
 
       {lessonStats && <PacingSection stats={lessonStats} />}


### PR DESCRIPTION
## Motivation

KPI snapshot shows on-target rate at 58.3% (yellow zone). The admin dashboard's 'Over-target' card is currently highlighted yellow whenever `overTarget > 0` — even if only 1 of 300 completions went over. This creates chronic noise that trains admins to ignore the card.

The meaningful threshold is already computed (`overTargetFractionHigh = overTargetFraction > 0.25`). The fix removes the always-yellow fallback so the card only highlights when the fraction is actually high. With 125/300 = 41.7% today, the card still highlights correctly — but for the right, trustworthy reason.

Also adds a secondary annotation line showing the raw percentage on the over-target card to make the fraction visible at a glance, matching the pattern used by the on-target rate card.

---
*Proposed by [plato-pilot](https://github.com/UIC-OSF/plato-pilot) — automated KPI-driven suggestions*