### PR TITLE
Add Test workflow + course-context unit coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ on:
   push:
     branches: [main, playground]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+# Runs `npm test` for both workspaces on every PR (drafts included — tests are
+# cheap and catching a regression early is the point) and on every push to a
+# protected branch. Independent of the AI Code Review workflow: that one runs
+# tests inside its prep step but soft-swallows failures (the agent is supposed
+# to flag them in its review). This workflow makes the test outcome a
+# first-class status check that gates the PR regardless of whether the AI
+# review fires.
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+  push:
+    branches: [main, playground]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        workspace: [client, server]
+    defaults:
+      run:
+        working-directory: ${{ matrix.workspace }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ${{ matrix.workspace }}/package-lock.json
+      - run: npm ci
+      - run: npm test

--- a/client/tests/lesson-context.test.js
+++ b/client/tests/lesson-context.test.js
@@ -80,6 +80,47 @@ describe('buildContext', () => {
     assert.ok(context.pacingDirective);
     assert.equal(context.postCompletionDirective, undefined);
   });
+
+  // Course taxonomy: when a lesson is part of a course, the server inlines
+  // `lesson.course = { id, name }` and buildContext surfaces just the name to
+  // the coach. Lessons without a course must produce no `course` key at all
+  // so the existing prompt contract for legacy lessons doesn't change.
+  it('includes course.name in the context when the lesson belongs to a course', () => {
+    const lesson = sampleLesson();
+    lesson.course = { id: 'course-abc', name: 'AI Foundations' };
+    const context = JSON.parse(buildContext(
+      lesson,
+      { status: 'active', progress: 2, activitiesCompleted: 3 },
+      'Learner profile summary',
+      'Alex'
+    ));
+
+    assert.deepEqual(context.course, { name: 'AI Foundations' });
+  });
+
+  it('omits course entirely when the lesson is not part of a course', () => {
+    const context = JSON.parse(buildContext(
+      sampleLesson(),
+      { status: 'active', progress: 2, activitiesCompleted: 3 },
+      'Learner profile summary',
+      'Alex'
+    ));
+
+    assert.equal('course' in context, false, 'no course key should be emitted');
+  });
+
+  it('omits course when lesson.course exists but has no name (defensive)', () => {
+    const lesson = sampleLesson();
+    lesson.course = { id: 'course-broken' }; // server returned a malformed inline
+    const context = JSON.parse(buildContext(
+      lesson,
+      { status: 'active', progress: 2, activitiesCompleted: 3 },
+      'Learner profile summary',
+      'Alex'
+    ));
+
+    assert.equal('course' in context, false);
+  });
 });
 
 describe('applyCoachResponseToKB', () => {


### PR DESCRIPTION
## Summary

Two related gaps surfaced while reviewing the CI pipeline:

1. **Tests aren't gating PRs at all.** The 296 existing tests (48 client + 251 server) only run inside `code-review.yml`'s prep step (server-only) or when an agent decides to. The Lint workflow runs `npm run lint`, never `npm test`. The AI review's `npm test` invocation soft-swallows failures via `|| echo "(tests failed…)"` and relies on the agent flagging them — which doesn't happen on Draft PRs (now skipped by design) or when the agent runs out of turns.
2. **The course branch in `buildContext` doesn't have unit coverage.** PR #157 added an `if (lesson.course && lesson.course.name)` block to surface the course name to the coach, but `client/tests/lesson-context.test.js` didn't get matching cases.

## Changes

- **`.github/workflows/test.yml` (new)** — runs `npm test` for both client and server in a matrix on every PR (drafts included — the gating logic for the *AI* review doesn't apply to plain test runs). Triggers on `opened`, `synchronize`, `ready_for_review`, and pushes to `main`/`playground`. ~25 lines.
- **`client/tests/lesson-context.test.js`** — three new cases:
  - `course: { name }` is included when the lesson has an inlined course record.
  - `course` is omitted entirely when the lesson is not part of a course (preserves the legacy context shape — important for not breaking active learners on pre-courses lessons).
  - `course` is omitted defensively when `lesson.course` exists but has no name.

## Test plan

- [x] `cd client && npm test` — 48 passing locally (was 45).
- [x] `cd server && npm test` — 251 passing locally.
- [ ] After this lands, the Test status check should appear on subsequent PRs and be required for merge (branch protection update is a separate maintainer action).

## Risk

CI-only change. Test suite already runs locally; this just gates it on every PR. The `code-review.yml` workflow is unchanged so the existing flow keeps working in parallel.

User impact: none — adds CI gate + unit test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)