### PR TITLE
Fix ComposeBar height collapse on scroll-induced remount (closes #161)

### DIFF
--- a/client/src/components/chat/ComposeBar.jsx
+++ b/client/src/components/chat/ComposeBar.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useId } from 'react';
+import { useState, useRef, useId, useEffect } from 'react';
 import { useAutoResize } from '../../hooks/useAutoResize.js';
 import { Button } from '@/components/ui/button';
 
@@ -23,6 +23,22 @@ export default function ComposeBar({
   const fileRef = useRef(null);
   const handleResize = useAutoResize();
   const inputId = useId();
+
+  // The lesson chat mounts two ComposeBar instances — an inline one and a
+  // fixed-overlay one — and a window-scroll listener swaps which is visible
+  // (`composePinned` in `LessonChat.jsx`). Each instance owns its own
+  // textarea ref. Without this effect, the freshly-mounted instance renders
+  // at `rows={1}` (its default) even when `text` already has multiple lines,
+  // because `useAutoResize` only fires on the `change` event and never sees
+  // the externally-supplied initial value. Result before this fix: when the
+  // user scrolls and the overlay swap happens, the textarea collapses back
+  // to a single line. (Bug #161.) Resync on every change to `text`, which
+  // covers both mount-with-prefilled-value and the rare case of the parent
+  // setting text from outside (e.g. retry / paste flows).
+  useEffect(() => {
+    if (!inputRef.current) return;
+    handleResize({ target: inputRef.current });
+  }, [text, handleResize]);
 
   const send = () => {
     const val = text.trim();


### PR DESCRIPTION
## Summary

Closes #161. When a learner typed a multi-line message and scrolled far enough to flip the compose-bar pin state, the textarea collapsed back to a single line.

## Root cause

`LessonChat` mounts **two** `ComposeBar` instances — an inline one and a fixed-overlay one — and a `window`-scroll listener (`composePinned` state) swaps which is visible. Each instance owns its own \`textarea\` ref. \`useAutoResize\` only fires on the \`change\` event, so when the freshly-visible instance mounted with an externally-supplied multi-line \`text\` prop, it had \`rows={1}\` and no inline \`style.height\` — rendering as a single row even though \`scrollHeight\` was 96px.

The pilot PR (#168) tried to fix this by tweaking \`useAutoResize.js\` to use \`height='0'\` instead of \`height='auto'\`, but that hook's only entry point is the change event — wrong code path entirely. (PR #168 also stacked an undisclosed full rewrite of \`LessonChat.jsx\` on top, removing accessibility infrastructure and other features.)

## Fix

One \`useEffect\` in \`ComposeBar\` that runs the resize handler whenever \`text\` changes:

\`\`\`js
useEffect(() => {
  if (!inputRef.current) return;
  handleResize({ target: inputRef.current });
}, [text, handleResize]);
\`\`\`

Covers both mount-with-prefilled-value (the actual bug) and rare parent-driven \`text\` updates (e.g. retry / paste flows).

## Test plan

- [x] Reproduced in Chrome at \`localhost:5173\`: typed 4 lines, scrolled to trigger pin → fixed-overlay textarea was \`h=\"\", vis=36\` (collapsed to 1 row).
- [x] After fix: same scroll, fixed-overlay reads \`h=\"96px\", vis=96\`. Round-trip (pin → unpin → pin) holds height in both states.
- [x] \`cd client && npm test\` — 51 pass.
- [x] \`cd client && npm run build\` — succeeds.

## Why not PR #168

PR #168 had two problems beyond the misdiagnosed root cause: (1) it bundled an undisclosed rewrite of \`LessonChat.jsx\` that removed all required accessibility features (\`role=\"log\"\`, \`role=\"status\"\` live region, sr-only speaker prefixes, \`data-chat-message\`, \`useChatKeyboardNav\`, \`useTitleNotification\`, the progress bar, the Objectives dialog, reset/export/delete, confetti, pinned header), (2) reversed the documented Cmd/Ctrl+Enter shortcut. Both review cycles flagged it; the bot's \"revert\" only stacked the hook change without removing the rewrite commit. This PR is the focused, minimal fix.

User impact: medium-low. Restores expected behavior for an existing user-reported bug. No surface change beyond what was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)