### PR TITLE
Stop claude-code-action from committing its workspace artifacts

### DIFF
--- a/.github/workflows/pilot.yml
+++ b/.github/workflows/pilot.yml
@@ -18,6 +18,18 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Prevent the agent / claude-code-action from committing its own workspace
+      # artifacts (e.g. .claude-pr/CLAUDE.md, a context copy the action stages
+      # inside the checkout). Writing to .git/info/exclude is per-clone — no
+      # tracked .gitignore change required, and `git add -A` will respect it.
+      - name: Ignore Claude Action workspace artifacts
+        run: |
+          mkdir -p .git/info
+          {
+            echo '.claude-pr/'
+            echo '.claude/'
+          } >> .git/info/exclude
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/revise.yml
+++ b/.github/workflows/revise.yml
@@ -24,6 +24,18 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
+      # Prevent the agent / claude-code-action from committing its own workspace
+      # artifacts (e.g. .claude-pr/CLAUDE.md, a context copy the action stages
+      # inside the checkout). Writing to .git/info/exclude is per-clone — no
+      # tracked .gitignore change required, and `git add -A` will respect it.
+      - name: Ignore Claude Action workspace artifacts
+        run: |
+          mkdir -p .git/info
+          {
+            echo '.claude-pr/'
+            echo '.claude/'
+          } >> .git/info/exclude
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Motivation

PR #178's \"Address code review feedback\" commit (\`5a7ea80\`) accidentally added a 183-line \`.claude-pr/CLAUDE.md\` to the tree. It's a copy of the repo's root \`CLAUDE.md\` that the Claude Action stages inside the checkout as its own context, and the agent's \`git add\` (or the action's auto-staging) swept it into the commit. PR #178 added a defensive \`.gitignore\` entry, but that doesn't prevent the same artifact from being committed by future runs that re-create the file before \`.gitignore\` exists in the working tree.

## Changes

Both workflows that commit (\`revise.yml\` and \`pilot.yml\`) now write \`.claude-pr/\` and \`.claude/\` to \`.git/info/exclude\` right after checkout, before the agent runs. \`.git/info/exclude\` is per-clone (never committed), and any subsequent \`git add -A\` / \`git add .\` respects it. No tracked \`.gitignore\` change needed.

## Test plan
- [ ] Confirm the next \`plato-pilot\` and \`plato-pilot-revise\` runs do not commit anything under \`.claude-pr/\` or \`.claude/\`.

## Note

This PR modifies workflow files that the auto-review uses, so per the existing self-modification guard the auto-review job will likely fail validation and the PR will need admin bypass to merge.