### PR TITLE
View as admins + reorder users table activity columns

### DIFF
--- a/client/src/components/modals/ViewAsUserModal.jsx
+++ b/client/src/components/modals/ViewAsUserModal.jsx
@@ -8,13 +8,14 @@ import { adminApi } from '../../pages/admin/adminApi.js';
 import { useAuth } from '../../contexts/AuthContext.jsx';
 
 /**
- * Admin "View as User" picker — single-select learner search.
+ * Admin "View as User" picker — single-select user search.
  *
  * Modeled on ShareLessonModal's user list pattern but with click-to-pick
- * rather than multi-select checkboxes. Admins are filtered out (no point
- * impersonating other admins, less foot-gun risk). On select we kick off
- * the impersonation start API call, persist target to sessionStorage,
- * close the modal, and let the caller redirect to the classroom.
+ * rather than multi-select checkboxes. Self is filtered out (can't view-as
+ * yourself); admins remain in the list so admin↔admin auditing is possible.
+ * On select we kick off the impersonation start API call, persist target
+ * to sessionStorage, close the modal, and let the caller redirect to the
+ * classroom.
  */
 export default function ViewAsUserModal({ open, onOpenChange, onStarted }) {
   const { startImpersonation, user: currentUser } = useAuth();
@@ -44,11 +45,10 @@ export default function ViewAsUserModal({ open, onOpenChange, onStarted }) {
   }, [open]);
 
   const filtered = useMemo(() => {
-    // Hide admins (don't impersonate self / other admins) and apply search.
-    const learners = users.filter(u => u.role !== 'admin' && u.userId !== currentUser?.userId);
-    if (!search.trim()) return learners;
+    const others = users.filter(u => u.userId !== currentUser?.userId);
+    if (!search.trim()) return others;
     const q = search.toLowerCase();
-    return learners.filter(u =>
+    return others.filter(u =>
       (u.name || '').toLowerCase().includes(q) ||
       (u.email || '').toLowerCase().includes(q) ||
       (u.username || '').toLowerCase().includes(q)
@@ -75,7 +75,7 @@ export default function ViewAsUserModal({ open, onOpenChange, onStarted }) {
         <DialogHeader>
           <DialogTitle>View as User</DialogTitle>
           <DialogDescription>
-            See the classroom as a specific learner — read-only.
+            See the classroom as a specific user — read-only.
           </DialogDescription>
         </DialogHeader>
 
@@ -92,24 +92,30 @@ export default function ViewAsUserModal({ open, onOpenChange, onStarted }) {
           ) : error ? (
             <div className="flex items-center justify-center h-full text-sm text-destructive p-4 text-center" role="alert">{error}</div>
           ) : filtered.length === 0 ? (
-            <div className="flex items-center justify-center h-full text-sm text-muted-foreground">No learners found.</div>
+            <div className="flex items-center justify-center h-full text-sm text-muted-foreground">No users found.</div>
           ) : (
-            <ul className="p-2 space-y-1" aria-label="Learners">
+            <ul className="p-2 space-y-1" aria-label="Users">
               {filtered.map(u => {
                 const label = u.name || u.username || u.email;
+                const isAdmin = u.role === 'admin';
                 return (
                   <li key={u.userId}>
                     <button
                       type="button"
                       onClick={() => handlePick(u)}
                       disabled={submitting}
-                      aria-label={`View as ${label}`}
+                      aria-label={`View as ${label}${isAdmin ? ' (admin)' : ''}`}
                       className="w-full flex items-center gap-3 rounded-md px-2 py-1.5 hover:bg-muted text-left text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed bg-transparent border-none outline-none focus:bg-muted focus-visible:ring-2 focus-visible:ring-ring"
                     >
                       <span className="flex-1 min-w-0">
                         <span className="font-medium truncate block">{label}</span>
                         {u.name && <span className="text-xs text-muted-foreground truncate block">{u.email}</span>}
                       </span>
+                      {isAdmin && (
+                        <span className="text-[10px] uppercase tracking-wide font-semibold px-1.5 py-0.5 rounded bg-primary/10 text-primary shrink-0" aria-hidden="true">
+                          Admin
+                        </span>
+                      )}
                     </button>
                   </li>
                 );

--- a/client/src/pages/admin/AdminUsers.jsx
+++ b/client/src/pages/admin/AdminUsers.jsx
@@ -664,10 +664,10 @@ export default function AdminUsers() {
                   <SortHeader sortKey="username" sortBy={sortBy} onSort={handleSort}>Username</SortHeader>
                   <SortHeader sortKey="group" sortBy={sortBy} onSort={handleSort}>Group</SortHeader>
                   <SortHeader sortKey="role" sortBy={sortBy} onSort={handleSort}>Role</SortHeader>
-                  {slackConnected && <TableHead>Slack</TableHead>}
                   <SortHeader sortKey="completed" sortBy={sortBy} onSort={handleSort} align="center">Completed</SortHeader>
                   <SortHeader sortKey="lastActive" sortBy={sortBy} onSort={handleSort}>Last active</SortHeader>
-                  <SortHeader sortKey="date" sortBy={sortBy} onSort={handleSort}>Date</SortHeader>
+                  <SortHeader sortKey="date" sortBy={sortBy} onSort={handleSort}>Date added</SortHeader>
+                  {slackConnected && <TableHead>Slack</TableHead>}
                   <TableHead><span className="sr-only">Actions</span></TableHead>
                 </TableRow>
               </TableHeader>
@@ -679,10 +679,10 @@ export default function AdminUsers() {
                     <TableCell className="text-muted-foreground">&mdash;</TableCell>
                     <TableCell>&mdash;</TableCell>
                     <TableCell><Badge variant="outline">Invited</Badge></TableCell>
-                    {slackConnected && <TableCell className="text-muted-foreground">&mdash;</TableCell>}
                     <TableCell className="text-muted-foreground text-center">&mdash;</TableCell>
                     <TableCell className="text-muted-foreground">&mdash;</TableCell>
                     <TableCell>{new Date(item.createdAt).toLocaleDateString()}</TableCell>
+                    {slackConnected && <TableCell className="text-muted-foreground">&mdash;</TableCell>}
                     <TableCell>
                       <div className="flex gap-1">
                         <Button variant="ghost" size="icon-xs" title="Resend" aria-label={`Resend invite to ${item.email}`} onClick={() => resendInvite(item.email)}>&#8635;</Button>
@@ -701,18 +701,6 @@ export default function AdminUsers() {
                         {item.role === 'admin' ? 'Admin' : 'User'}
                       </Badge>
                     </TableCell>
-                    {slackConnected && (
-                      <TableCell>
-                        {item._user.slackUserId ? (
-                          <span title={item._user.slackUserId} className="text-xs">
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="inline-block mr-1 text-muted-foreground" aria-label="Slack linked">
-                              <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zm-1.27 0a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.163 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.163 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.163 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zm0-1.27a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.315A2.528 2.528 0 0 1 24 15.163a2.528 2.528 0 0 1-2.522 2.523h-6.315z" fill="currentColor"/>
-                            </svg>
-                            Linked
-                          </span>
-                        ) : <span className="text-muted-foreground">&mdash;</span>}
-                      </TableCell>
-                    )}
                     <TableCell className="text-center">
                       {typeof item._user.lessonsCompleted === 'number' ? (
                         <div className="inline-flex">
@@ -732,6 +720,18 @@ export default function AdminUsers() {
                         : <span className="text-muted-foreground">&mdash;</span>}
                     </TableCell>
                     <TableCell>{new Date(item.createdAt).toLocaleDateString()}</TableCell>
+                    {slackConnected && (
+                      <TableCell>
+                        {item._user.slackUserId ? (
+                          <span title={item._user.slackUserId} className="text-xs">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="inline-block mr-1 text-muted-foreground" aria-label="Slack linked">
+                              <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zm-1.27 0a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.163 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.163 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.163 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zm0-1.27a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.315A2.528 2.528 0 0 1 24 15.163a2.528 2.528 0 0 1-2.522 2.523h-6.315z" fill="currentColor"/>
+                            </svg>
+                            Linked
+                          </span>
+                        ) : <span className="text-muted-foreground">&mdash;</span>}
+                      </TableCell>
+                    )}
                     <TableCell>
                       <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
                         <PluginSlot name="adminUserRowAction" context={{ user: item._user }} />


### PR DESCRIPTION
## Summary
- **View as User** picker now includes admins. The client-side filter that hid admins (`ViewAsUserModal.jsx`) is gone; the server endpoint already accepts admin targets, so this was purely a UI block. An "Admin" pill renders next to admin rows so it's obvious which entries are admins.
- **Admin → Users** table column order changed so the activity columns sit next to Role: Name · Email · Username · Group · Role · **Completed · Last active · Date added** · [Slack] · Actions.
- Renamed the "Date" column header to **"Date added"** (data is unchanged — still `createdAt`). The previous label was ambiguous (could be read as last login, last activity, etc.).

## Test plan
- [ ] Open Admin → Users; confirm column order: Name, Email, Username, Group, Role, Completed, Last active, Date added, (Slack if connected), Actions
- [ ] Confirm "Date added" header sorts on `createdAt` (existing sortKey `date` retained — no resort surprises)
- [ ] Click "View as User" in the admin bar; verify other admins now appear in the picker with an "Admin" tag
- [ ] Pick an admin → verify impersonation starts and the classroom loads as that admin
- [ ] Pick a non-admin → existing happy path still works
- [ ] Slack column still renders only when `slackConnected`, now to the right of Date added

🤖 Generated with [Claude Code](https://claude.com/claude-code)