### PR TITLE
KB editor: summarizing extractor + markdown preview

### DIFF
--- a/client/prompts/knowledge-base-editor.md
+++ b/client/prompts/knowledge-base-editor.md
@@ -38,6 +38,9 @@ The Coach uses the KB to answer learner questions about the program, tailor acti
 - Who the key people are (so the Coach can direct learners to the right person for help)
 - Program logistics (timeline, platforms, channels) — so the Coach doesn't give outdated or wrong info
 - FAQs — the Coach will use these to answer common questions without hallucinating
+- **Concise** — the KB is appended to every coach conversation, so it shares the model's context budget. Aim for a tight quick-reference (a few KB at most), not an exhaustive manual.
+
+Keep your guidance pointed at the essentials. When an admin gives you a long, rambling answer, capture the few facts that matter rather than everything they said — the saved KB should read as a crisp reference.
 
 ## What the knowledge base is for
 

--- a/client/prompts/knowledge-base-extractor.md
+++ b/client/prompts/knowledge-base-extractor.md
@@ -18,8 +18,16 @@ You will receive a message with two sections:
 
 ## Your task
 
-- If creating from scratch (no existing KB): synthesize all information from the conversation into a well-structured knowledge base.
-- If updating an existing KB: apply ONLY the changes discussed in the conversation. Preserve everything from the existing KB that was not explicitly changed. Do not remove, reword, or reorganize content that wasn't discussed.
+- If creating from scratch (no existing KB): synthesize and **summarize** the information from the conversation into a concise, well-structured reference.
+- If updating an existing KB: apply ONLY the changes discussed in the conversation. Preserve the facts already in the KB that weren't explicitly changed — but you may tighten wording and merge redundancy while doing so. Don't drop information the admin didn't ask to remove.
+
+## Be concise — this is a reference, not a transcript
+
+The knowledge base is appended to **every** coach conversation, so its size is part of the platform's context budget. A bloated KB crowds out the actual lesson and can overflow the model's context window.
+
+- **Summarize, don't transcribe.** Capture the essential facts in crisp prose, short bullets, and tight **Q:** / **A:** pairs. Never reproduce the back-and-forth of the conversation.
+- **Consolidate.** Merge duplicate or overlapping points into a single clear statement. Keep each section to what a coach actually needs.
+- **Target a few KB of markdown at most.** If the material is large, prefer the highest-signal facts over completeness. It's a quick-reference, not a manual.
 
 ## Output format
 

--- a/client/src/pages/admin/AdminCustomizer.jsx
+++ b/client/src/pages/admin/AdminCustomizer.jsx
@@ -9,7 +9,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 
 import { renderMd } from '../../lib/helpers.js';
 import { converseStream, extractKBMarkdown } from '../../../js/orchestrator.js';
-import { parseResponse, cleanStream } from '../../lib/lessonCreationEngine.js';
+import { parseResponse, cleanStream, buildConversationText } from '../../lib/lessonCreationEngine.js';
 import { useStreamedText } from '../../hooks/useStreamedText.js';
 import { useTitleNotification } from '../../hooks/useTitleNotification.js';
 import { MSG_TYPES } from '../../lib/constants.js';
@@ -19,6 +19,7 @@ import ComposeBar from '../../components/chat/ComposeBar.jsx';
 import AssistantMessage from '../../components/chat/AssistantMessage.jsx';
 import UserMessage from '../../components/chat/UserMessage.jsx';
 import ThinkingSpinner from '../../components/chat/ThinkingSpinner.jsx';
+import MarkdownPreviewPane from './MarkdownPreviewPane.jsx';
 
 export default function AdminCustomizer() {
   const location = useLocation();
@@ -292,6 +293,17 @@ function KBEditor({ initialContent, onSave, onCancel, initialConversation, initi
   const [srAnnouncement, setSrAnnouncement] = useState('');
   const notifyTitle = useTitleNotification('Customizer — Admin');
 
+  // Markdown preview pane. Refreshed manually via the knowledge-base-extractor
+  // agent; never persisted until the admin clicks Save. Mirrors the lesson
+  // editor (NewLessonView). When editing, the saved content seeds the preview
+  // already in sync with the resumed conversation.
+  const [previewMarkdown, setPreviewMarkdown] = useState(initialContent || '');
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState('');
+  const [previewSyncedAt, setPreviewSyncedAt] = useState(
+    initialContent ? (initialConversation?.length || 0) : 0
+  );
+
   // Auto-save KB conversation after each exchange
   const readinessRef = useRef(readiness);
   useEffect(() => { readinessRef.current = readiness; }, [readiness]);
@@ -389,13 +401,15 @@ function KBEditor({ initialContent, onSave, onCancel, initialConversation, initi
     setError('');
     setBusy('creating');
     try {
-      const conversationText = chatMessages.map(m => `${m.role === 'user' ? 'User' : 'Agent'}: ${m.content}`).join('\n\n');
-      const md = await extractKBMarkdown(conversationText, initialContent);
+      const md = await extractKBMarkdown(buildConversationText(chatMessages), initialContent);
       if (!md || md.length < 50) {
         setError('Could not generate a knowledge base from the conversation. Keep adding information.');
         setBusy('');
         return;
       }
+      // Keep the preview in sync with what we're about to save.
+      setPreviewMarkdown(md);
+      setPreviewSyncedAt(chatMessages.length);
       const conversation = chatMessages.map(m => ({ role: m.role, content: m.content, msgType: m.msgType }));
       await onSave(md, conversation, readiness);
     } catch (e) {
@@ -405,6 +419,27 @@ function KBEditor({ initialContent, onSave, onCancel, initialConversation, initi
   }
 
   const isBusy = !!busy;
+  const previewStale = !!previewMarkdown && chatMessages.length > previewSyncedAt;
+
+  // Refresh the markdown preview by re-running the knowledge-base-extractor.
+  // Runs independently of the chat — never sets `busy`.
+  async function handleRefreshPreview() {
+    if (chatMessages.length === 0) {
+      setPreviewError('Start the conversation first, then refresh.');
+      return;
+    }
+    setPreviewError('');
+    setPreviewLoading(true);
+    try {
+      const md = await extractKBMarkdown(buildConversationText(chatMessages), initialContent);
+      setPreviewMarkdown(md);
+      setPreviewSyncedAt(chatMessages.length);
+    } catch (e) {
+      setPreviewError(e.message || 'Failed to generate preview.');
+    } finally {
+      setPreviewLoading(false);
+    }
+  }
 
   const renderMessage = (msg, idx) => {
     if (msg.msgType === MSG_TYPES.USER) return <UserMessage key={idx} content={msg.content} />;
@@ -460,24 +495,45 @@ function KBEditor({ initialContent, onSave, onCancel, initialConversation, initi
         </div>
       )}
 
-      <div className="rounded-2xl bg-muted/40 border border-border p-4">
-        <div className="mb-3">
-          <ChatArea announcement={srAnnouncement}>
-            {chatMessages.map(renderMessage)}
-            {displayText != null && displayText.length > 0 && (
-              <AssistantMessage content={displayText} streaming />
-            )}
-            {busy === 'starting' && !displayText && <ThinkingSpinner text="Starting..." />}
-            {busy === 'creating' && <ThinkingSpinner text="Generating knowledge base..." />}
-            {busy === 'qa' && !displayText && <ThinkingSpinner />}
-          </ChatArea>
+      {/* Chat (left) + markdown preview (right). Stacks vertically below `lg`. */}
+      <div className="flex flex-col lg:flex-row gap-4">
+        <div className="lg:w-3/5 min-w-0">
+          <div className="rounded-2xl bg-muted/40 border border-border p-4">
+            <div className="mb-3">
+              <ChatArea announcement={srAnnouncement}>
+                {chatMessages.map(renderMessage)}
+                {displayText != null && displayText.length > 0 && (
+                  <AssistantMessage content={displayText} streaming />
+                )}
+                {busy === 'starting' && !displayText && <ThinkingSpinner text="Starting..." />}
+                {busy === 'creating' && <ThinkingSpinner text="Generating knowledge base..." />}
+                {busy === 'qa' && !displayText && <ThinkingSpinner />}
+              </ChatArea>
+            </div>
+
+            <ComposeBar
+              placeholder="Tell me about your program..."
+              onSend={handleSend}
+              disabled={isBusy}
+            />
+          </div>
         </div>
 
-        <ComposeBar
-          placeholder="Tell me about your program..."
-          onSend={handleSend}
-          disabled={isBusy}
-        />
+        <div className="lg:w-2/5 min-w-0">
+          <MarkdownPreviewPane
+            markdown={previewMarkdown}
+            loading={previewLoading}
+            error={previewError}
+            stale={previewStale}
+            saveLabel={isEditing ? 'Update Knowledge Base' : 'Save Knowledge Base'}
+            refreshDisabled={previewLoading || isBusy}
+            onRefresh={handleRefreshPreview}
+            title="Knowledge base preview"
+            ariaLabel="Knowledge base markdown preview"
+            noun="knowledge base"
+            emptyHint="No preview yet. Keep chatting with the editor, then click “Generate preview” to see the generated knowledge base."
+          />
+        </div>
       </div>
     </div>
   );

--- a/client/src/pages/admin/AdminKBSetup.jsx
+++ b/client/src/pages/admin/AdminKBSetup.jsx
@@ -4,7 +4,7 @@ import { adminApi } from './adminApi.js';
 import { Button } from '@/components/ui/button';
 
 import { converseStream, extractKBMarkdown } from '../../../js/orchestrator.js';
-import { parseResponse, cleanStream } from '../../lib/lessonCreationEngine.js';
+import { parseResponse, cleanStream, buildConversationText } from '../../lib/lessonCreationEngine.js';
 import { useStreamedText } from '../../hooks/useStreamedText.js';
 import { useTitleNotification } from '../../hooks/useTitleNotification.js';
 import { MSG_TYPES } from '../../lib/constants.js';
@@ -14,6 +14,7 @@ import ComposeBar from '../../components/chat/ComposeBar.jsx';
 import AssistantMessage from '../../components/chat/AssistantMessage.jsx';
 import UserMessage from '../../components/chat/UserMessage.jsx';
 import ThinkingSpinner from '../../components/chat/ThinkingSpinner.jsx';
+import MarkdownPreviewPane from './MarkdownPreviewPane.jsx';
 
 export default function AdminKBSetup() {
   const navigate = useNavigate();
@@ -27,6 +28,13 @@ export default function AdminKBSetup() {
   const pendingRef = useRef(null);
   const [srAnnouncement, setSrAnnouncement] = useState('');
   const notifyTitle = useTitleNotification('Set Up Knowledge Base — plato');
+
+  // Markdown preview pane — manual refresh via the knowledge-base-extractor,
+  // mirroring the lesson editor. Never persisted until the admin saves.
+  const [previewMarkdown, setPreviewMarkdown] = useState('');
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState('');
+  const [previewSyncedAt, setPreviewSyncedAt] = useState(0);
 
   useEffect(() => {
     document.title = 'Set Up Knowledge Base — plato';
@@ -111,13 +119,14 @@ export default function AdminKBSetup() {
     setError('');
     setBusy('creating');
     try {
-      const conversationText = chatMessages.map(m => `${m.role === 'user' ? 'User' : 'Agent'}: ${m.content}`).join('\n\n');
-      const md = await extractKBMarkdown(conversationText);
+      const md = await extractKBMarkdown(buildConversationText(chatMessages));
       if (!md || md.length < 50) {
         setError('Could not generate a knowledge base from the conversation. Keep adding information.');
         setBusy('');
         return;
       }
+      setPreviewMarkdown(md);
+      setPreviewSyncedAt(chatMessages.length);
       const conversation = chatMessages.map(m => ({ role: m.role, content: m.content, msgType: m.msgType }));
       await adminApi('PUT', '/v1/admin/knowledge-base', { content: md, conversation, readiness });
       navigate('/plato');
@@ -128,6 +137,27 @@ export default function AdminKBSetup() {
   }
 
   const isBusy = !!busy;
+  const previewStale = !!previewMarkdown && chatMessages.length > previewSyncedAt;
+
+  // Refresh the markdown preview by re-running the knowledge-base-extractor.
+  // Runs independently of the chat — never sets `busy`.
+  async function handleRefreshPreview() {
+    if (chatMessages.length === 0) {
+      setPreviewError('Start the conversation first, then refresh.');
+      return;
+    }
+    setPreviewError('');
+    setPreviewLoading(true);
+    try {
+      const md = await extractKBMarkdown(buildConversationText(chatMessages));
+      setPreviewMarkdown(md);
+      setPreviewSyncedAt(chatMessages.length);
+    } catch (e) {
+      setPreviewError(e.message || 'Failed to generate preview.');
+    } finally {
+      setPreviewLoading(false);
+    }
+  }
 
   const renderMessage = (msg, idx) => {
     if (msg.msgType === MSG_TYPES.USER) return <UserMessage key={idx} content={msg.content} />;
@@ -135,7 +165,7 @@ export default function AdminKBSetup() {
   };
 
   return (
-    <main className="max-w-2xl mx-auto p-6" aria-label="Knowledge base setup">
+    <main className="max-w-5xl mx-auto p-6" aria-label="Knowledge base setup">
       <div className="flex items-center justify-between mb-2">
         <h1 className="text-2xl font-bold">Set Up Your Knowledge Base</h1>
         <Button variant="ghost" size="sm" onClick={() => navigate('/plato')}>Skip for now</Button>
@@ -183,24 +213,45 @@ export default function AdminKBSetup() {
         </div>
       )}
 
-      <div className="rounded-2xl bg-muted/40 border border-border p-4">
-        <div className="mb-3">
-          <ChatArea announcement={srAnnouncement}>
-            {chatMessages.map(renderMessage)}
-            {displayText != null && displayText.length > 0 && (
-              <AssistantMessage content={displayText} streaming />
-            )}
-            {busy === 'starting' && !displayText && <ThinkingSpinner text="Starting..." />}
-            {busy === 'creating' && <ThinkingSpinner text="Generating knowledge base..." />}
-            {busy === 'qa' && !displayText && <ThinkingSpinner />}
-          </ChatArea>
+      {/* Chat (left) + markdown preview (right). Stacks vertically below `lg`. */}
+      <div className="flex flex-col lg:flex-row gap-4">
+        <div className="lg:w-3/5 min-w-0">
+          <div className="rounded-2xl bg-muted/40 border border-border p-4">
+            <div className="mb-3">
+              <ChatArea announcement={srAnnouncement}>
+                {chatMessages.map(renderMessage)}
+                {displayText != null && displayText.length > 0 && (
+                  <AssistantMessage content={displayText} streaming />
+                )}
+                {busy === 'starting' && !displayText && <ThinkingSpinner text="Starting..." />}
+                {busy === 'creating' && <ThinkingSpinner text="Generating knowledge base..." />}
+                {busy === 'qa' && !displayText && <ThinkingSpinner />}
+              </ChatArea>
+            </div>
+
+            <ComposeBar
+              placeholder="Tell me about your program..."
+              onSend={handleSend}
+              disabled={isBusy}
+            />
+          </div>
         </div>
 
-        <ComposeBar
-          placeholder="Tell me about your program..."
-          onSend={handleSend}
-          disabled={isBusy}
-        />
+        <div className="lg:w-2/5 min-w-0">
+          <MarkdownPreviewPane
+            markdown={previewMarkdown}
+            loading={previewLoading}
+            error={previewError}
+            stale={previewStale}
+            saveLabel="Save Knowledge Base"
+            refreshDisabled={previewLoading || isBusy}
+            onRefresh={handleRefreshPreview}
+            title="Knowledge base preview"
+            ariaLabel="Knowledge base markdown preview"
+            noun="knowledge base"
+            emptyHint="No preview yet. Keep chatting with the editor, then click “Generate preview” to see the generated knowledge base."
+          />
+        </div>
       </div>
     </main>
   );

--- a/client/src/pages/admin/AdminLessons.jsx
+++ b/client/src/pages/admin/AdminLessons.jsx
@@ -12,7 +12,7 @@ import {
 import ConfirmModal from '../../components/modals/ConfirmModal.jsx';
 import ShareLessonModal from '../../components/modals/ShareLessonModal.jsx';
 import CoursesModal from './CoursesModal.jsx';
-import LessonPreviewPane from './LessonPreviewPane.jsx';
+import MarkdownPreviewPane from './MarkdownPreviewPane.jsx';
 import { converseStream, extractLessonMarkdown } from '../../../js/orchestrator.js';
 import { parseLessonPrompt } from '../../../js/lessonOwner.js';
 import { parseResponse, cleanStream, buildConversationText } from '../../lib/lessonCreationEngine.js';
@@ -729,12 +729,12 @@ function NewLessonView({ onSave, onCancel, onError: _onError, lessonId, isDraft,
         </div>
 
         <div className="lg:w-2/5 min-w-0">
-          <LessonPreviewPane
+          <MarkdownPreviewPane
             markdown={previewMarkdown}
             loading={previewLoading}
             error={previewError}
             stale={previewStale}
-            isCreate={isCreate}
+            saveLabel={isCreate ? 'Create Lesson' : 'Update Lesson'}
             refreshDisabled={previewLoading || isBusy}
             onRefresh={handleRefreshPreview}
           />

--- a/client/src/pages/admin/MarkdownPreviewPane.jsx
+++ b/client/src/pages/admin/MarkdownPreviewPane.jsx
@@ -3,22 +3,29 @@ import { Button } from '@/components/ui/button';
 import { renderMd } from '../../lib/helpers.js';
 
 /**
- * Read-only markdown preview pane for the lesson editor (NewLessonView).
- * Presentational only — all state is owned by NewLessonView. The preview is
- * refreshed manually (onRefresh runs the lesson-extractor agent); it is never
- * persisted until the admin clicks "Create/Update Lesson".
+ * Read-only markdown preview pane for the conversational admin editors (lesson
+ * creator + knowledge base editor). Presentational only — all state is owned by
+ * the parent view. The preview is refreshed manually (onRefresh runs the
+ * relevant extractor agent); it is never persisted until the admin clicks the
+ * parent's save button.
+ *
+ * Copy is parametrized so the same pane serves both editors; the defaults
+ * preserve the original lesson-editor behavior.
  */
-export default function LessonPreviewPane({
+export default function MarkdownPreviewPane({
   markdown,
   loading,
   error,
   stale,
-  isCreate,
-  refreshDisabled,
+  saveLabel = 'Create Lesson',
   onRefresh,
+  refreshDisabled,
+  title = 'Lesson preview',
+  ariaLabel = 'Lesson markdown preview',
+  noun = 'lesson',
+  emptyHint = 'No preview yet. Keep chatting with the editor, then click “Generate preview” to see the generated lesson markdown.',
 }) {
   const hasContent = !!markdown?.trim();
-  const saveLabel = isCreate ? 'Create Lesson' : 'Update Lesson';
   // Before the first extraction there is nothing to refresh — it's a generate.
   const refreshLabel = loading
     ? (hasContent ? 'Refreshing…' : 'Generating…')
@@ -32,27 +39,27 @@ export default function LessonPreviewPane({
   const wasLoading = useRef(loading);
   useEffect(() => {
     if (loading && !wasLoading.current) {
-      setAnnouncement(hasContent ? 'Refreshing lesson preview' : 'Generating lesson preview');
+      setAnnouncement(hasContent ? `Refreshing ${noun} preview` : `Generating ${noun} preview`);
     } else if (!loading && wasLoading.current) {
-      setAnnouncement(error ? '' : 'Lesson preview updated');
+      setAnnouncement(error ? '' : `${title} updated`);
     }
     wasLoading.current = loading;
-  }, [loading, error, hasContent]);
+  }, [loading, error, hasContent, noun, title]);
 
   return (
     <aside
-      aria-label="Lesson markdown preview"
+      aria-label={ariaLabel}
       className="flex flex-col rounded-2xl bg-muted/40 border border-border p-4"
     >
       <div className="flex items-center justify-between gap-2 mb-2">
-        <h2 className="text-sm font-semibold">Lesson preview</h2>
+        <h2 className="text-sm font-semibold">{title}</h2>
         <Button
           variant="outline"
           size="sm"
           className="shrink-0"
           onClick={onRefresh}
           disabled={refreshDisabled}
-          aria-describedby={showStaleHint ? 'lesson-preview-stale-hint' : undefined}
+          aria-describedby={showStaleHint ? 'md-preview-stale-hint' : undefined}
         >
           {refreshLabel}
         </Button>
@@ -62,12 +69,12 @@ export default function LessonPreviewPane({
           Linked to the refresh button via aria-describedby so a screen-reader
           user hears why a refresh is worthwhile when the button is focused. */}
       {showStaleHint && (
-        <p id="lesson-preview-stale-hint" className="text-xs text-muted-foreground mb-2">
+        <p id="md-preview-stale-hint" className="text-xs text-muted-foreground mb-2">
           Preview may be outdated — refresh to update.
         </p>
       )}
 
-      {/* Persistent reminder: the preview is not the saved lesson. */}
+      {/* Persistent reminder: the preview is not saved. */}
       <p
         role="note"
         className="text-xs rounded-md bg-amber-50 text-amber-800 border border-amber-200 px-3 py-2 mb-3"
@@ -97,8 +104,7 @@ export default function LessonPreviewPane({
           />
         ) : (
           <div className="text-sm text-muted-foreground py-12 text-center">
-            No preview yet. Keep chatting with the editor, then click
-            &ldquo;Generate preview&rdquo; to see the generated lesson markdown.
+            {emptyHint}
           </div>
         )}
       </div>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,7 +34,7 @@ it, and its purpose:
 - **lesson-owner** — Reads: lesson prompt, learner profile. Initializes per-lesson KB.
 - **lesson-extractor** — Reads: conversation text only. Extracts lesson markdown from creation chat.
 - **knowledge-base-editor** — Reads: program KB. Helps admins create/edit the KB via conversation.
-- **knowledge-base-extractor** — Reads: existing KB + conversation. Merges changes into updated KB markdown.
+- **knowledge-base-extractor** — Reads: existing KB + conversation. Merges changes into updated KB markdown. **Summarizes, doesn't transcribe** — it produces a concise reference (a few KB), because the full KB is re-appended to every coach turn and an unbounded KB overflows the context window (and silently truncates against the extractor's own `maxTokens`). The editor (`AdminCustomizer`/`AdminKBSetup`) windows live turns to the last 15, like the lesson creator.
 - **learner-profile-owner** — Reads: learner profile, lesson KB. Full profile update on lesson completion.
 - **learner-profile-update** — Reads: learner profile, activity context. Incremental profile updates during lessons.
 
@@ -189,17 +189,19 @@ redirects to `/plato/lessons`, but a 404 on a freshly-minted draft id (within
 bouncing. `AdminLessons` keys `NewLessonView` on `lessonId` so switching lessons
 remounts cleanly.
 
-**Markdown preview pane** (`client/src/pages/admin/LessonPreviewPane.jsx`):
-chat left, rendered lesson markdown right, stacking below `lg`. The preview is
+**Markdown preview pane** (`client/src/pages/admin/MarkdownPreviewPane.jsx`):
+chat left, rendered markdown right, stacking below `lg`. The preview is
 **manually refreshed** via a "Generate preview" / "Refresh preview" button that
-re-runs the `lesson-extractor` agent (`extractLessonMarkdown`) — it does NOT
-auto-update per message and runs no AI call on editor open. On open the pane
-shows the lesson's already-saved markdown (edit) or a quiet empty-state (new
-draft). Once the conversation advances past the last refresh a "Preview may be
-outdated" hint appears. The preview is **not persisted** — a standing note tells
-the admin to click "Create/Update Lesson" to save. `buildConversationText`
-(`client/src/lib/lessonCreationEngine.js`) is the shared builder for the
-`lesson-extractor` input, used by both the finalize and preview-refresh paths.
+re-runs the relevant extractor agent — it does NOT auto-update per message and
+runs no AI call on editor open. On open the pane shows the already-saved markdown
+(edit) or a quiet empty-state (new). Once the conversation advances past the last
+refresh a "Preview may be outdated" hint appears. The preview is **not
+persisted** — a standing note tells the admin to click the save button.
+`buildConversationText` (`client/src/lib/lessonCreationEngine.js`) is the shared
+builder for the extractor input, used by both the finalize and preview-refresh
+paths. The same pane (copy parametrized via props) backs both the lesson editor
+(`extractLessonMarkdown`) and the **knowledge base editor**
+(`AdminCustomizer` + `AdminKBSetup`, `extractKBMarkdown`).
 
 ### Coach directive
 


### PR DESCRIPTION
Fixes two knowledge-base problems by **mirroring the lesson creator** (per direction: "do what we've done in the lesson creator").

## Problem 1 — KB overflows the coach context
The KB extractor was instructed to *"preserve everything… do not remove, reword, or reorganize"* — it **transcribed** the admin conversation, so the KB grew large. That full markdown is re-injected into **every** coach turn (`orchestrator.js:130`), so an oversized KB eventually overflows the window. A latent data-loss bug rode along: `extractKBMarkdown` is capped at `maxTokens: 4096`, so a large KB silently truncated mid-document on the next save.

**Fix:** the extractor now **summarizes into a concise reference** (a few KB) instead of transcribing; the editor prompt nudges toward the same. Concise output also stays well under the token cap, closing the truncation bug. (Live turns were already windowed to the last 15 in both KB views, exactly like the lesson creator.)

## Problem 2 — no preview in the KB editing UX
The KB editor showed only chat + a readiness bar; markdown wasn't visible until after save. It now has the **lesson editor's side-by-side preview** — a manual "Refresh preview" that runs `extractKBMarkdown`, a staleness hint, and a not-saved note — in **both** the Customizer (`AdminCustomizer`) and the post-login setup (`AdminKBSetup`).

## Reuse, not rebuild
- `LessonPreviewPane` → **`MarkdownPreviewPane`** (copy parametrized via props, lesson defaults preserved); used by the lesson editor + both KB views.
- Shared `buildConversationText` (`lessonCreationEngine.js`) now feeds the KB extractor too.
- No new agent, no size meter / hard cap — the lesson-creator pattern (windowed turns + summarizing extractor + manual preview).

## Testing
- `client && npm test` → 101 pass; lint 0 errors (the 3 warnings in touched files pre-date this change).
- `server && npm test` → unchanged (no server edits; the lone `db-sqlite` failure is an unrelated `better-sqlite3` native ABI mismatch in this env).
- Manual: build a KB in Customizer + KB setup, confirm preview renders/refreshes/staleness, the generated KB reads as a concise reference, and the lesson editor preview still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)