### PR TITLE
Fix issue-intake sweep backstop: allow github-actions bot

### DIFF
--- a/.github/workflows/issue-intake.yml
+++ b/.github/workflows/issue-intake.yml
@@ -68,7 +68,11 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
         with:
           use_bedrock: "true"
-          allowed_bots: "claude"
+          # `claude` for in-pipeline bot chatter; `github-actions` so the
+          # issue-intake-sweep backstop's workflow_dispatch retries (which run
+          # as the github-actions[bot] actor) aren't rejected as a non-human
+          # actor — otherwise the self-healing sweep is a silent no-op.
+          allowed_bots: "claude,github-actions"
           show_full_output: true
           # Haiku is plenty for classification: read issue, decide A/B/C, label, comment.
           # Sonnet's reasoning headroom is wasted here — saves ~3x on per-run cost.

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -110,6 +110,13 @@ label-less issues older than an hour and re-dispatches `issue-intake.yml` on eac
 via its `workflow_dispatch` input; self-healing, since a successful re-run adds
 the label and drops the issue from the next sweep.
 
+The sweep's re-dispatch runs as the `github-actions[bot]` actor, so
+`issue-intake.yml` must keep `github-actions` in `allowed_bots` — otherwise
+`claude-code-action` rejects every retry as a "non-human actor" and the backstop
+becomes a silent no-op (this is also the only path that triages issues from
+reporters without repo write access, whose on-open run `claude-code-action`
+blocks by design).
+
 ## Auto code review (`code-review.yml`)
 
 Runs on every PR (opened + synchronize) and posts a review as `claude[bot]`.


### PR DESCRIPTION
## Why #220 (and others) never got an intake response

Two compounding failures, both confirmed in run logs:

1. **On-open run blocked by write-access gate.** #220's reporter (`mwgil10`) has no repo write access, so `claude-code-action`'s built-in permission gate failed the `issues: opened` run with *"User does not have write access on this repository"* — by design.

2. **The sweep backstop was a silent no-op.** `issue-intake-sweep.yml` correctly detected #220 as untriaged and re-dispatched `issue-intake.yml` every 6 hours, but every dispatch failed with *"Workflow initiated by non-human actor: github-actions (type: Bot). Add bot to allowed_bots list."* The sweep dispatches via `GITHUB_TOKEN` (actor = `github-actions[bot]`), which `allowed_bots: "claude"` excluded.

So #220 fell into exactly the black hole the sweep exists to prevent (#193's failure mode), but the sweep itself couldn't heal anything.

## Fix

Add `github-actions` to `allowed_bots`. The bot-initiated dispatch is also the *only* triage path for issues from reporters without write access (whose on-open run is blocked by design), so this makes that path work too.

Docs updated in `AUTOMATION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)