### PR TITLE
Surface real cause of image-read failures; tolerate partial reads (#228)

### DIFF
--- a/client/src/components/chat/ComposeBar.jsx
+++ b/client/src/components/chat/ComposeBar.jsx
@@ -121,7 +121,26 @@ export default function ComposeBar({
     setLoadingImages(true);
     setLoadingCount(valid.length);
     try {
-      const loaded = await Promise.all(valid.map(readImageAsDataUrl));
+      // Read each file independently (allSettled, not all): a single
+      // unreadable file must not discard the others. FileReader rejects with
+      // a DOMException whose `.name` is the actionable signal — e.g.
+      // NotReadableError (file locked by antivirus / in use) or NotFoundError
+      // (a OneDrive "files on-demand" entry not yet downloaded locally). We
+      // surface that name so a screenshot of the alert is self-diagnosing
+      // (issue #228 — "Failed to read image" with no other clue).
+      const settled = await Promise.allSettled(valid.map(readImageAsDataUrl));
+      const loaded = [];
+      const readErrors = [];
+      for (const r of settled) {
+        if (r.status === 'fulfilled') loaded.push(r.value);
+        else { readErrors.push(r.reason); console.error('[plato] failed to read image', r.reason); }
+      }
+      if (readErrors.length > 0) {
+        const reason = readErrors[0]?.name || readErrors[0]?.message || 'unknown error';
+        const n = readErrors.length;
+        alert(`Couldn't read ${n} image${n === 1 ? '' : 's'} (${reason}). Please try again or pick a different file.`);
+      }
+      if (loaded.length === 0) return;
       // Compress before the image enters the compose state: it's persisted
       // one-per-record as `screenshot:*` sync data, which DynamoDB caps at
       // 400 KB. A raw screenshot can blow that limit (issues #191, #193).
@@ -130,13 +149,14 @@ export default function ComposeBar({
         dataUrl: await compressImageDataUrl(img.dataUrl),
       })));
       // Filter out images that couldn't be compressed enough (null dataUrl)
-      const valid = compressed.filter(img => img.dataUrl !== null);
-      if (valid.length < compressed.length) {
-        alert(`${compressed.length - valid.length} image(s) were too large and could not be compressed enough. Please use smaller images.`);
+      const usable = compressed.filter(img => img.dataUrl !== null);
+      if (usable.length < compressed.length) {
+        alert(`${compressed.length - usable.length} image(s) were too large and could not be compressed enough. Please use smaller images.`);
       }
-      setImages([...images, ...valid].slice(0, MAX_IMAGES));
-    } catch {
-      alert('Failed to read image. Please try again.');
+      setImages([...images, ...usable].slice(0, MAX_IMAGES));
+    } catch (err) {
+      console.error('[plato] image processing failed', err);
+      alert(`Failed to read image (${err?.name || err?.message || 'unknown error'}). Please try again.`);
     } finally {
       setLoadingImages(false);
       setLoadingCount(0);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,6 +68,13 @@ is its own `screenshot:<key>` record, and the message stores only
   (`client/src/lib/imageCompression.js`) to stay well under the per-record
   limit, persisted one-per-record, and excluded from the bulk `GET /v1/sync`
   payload (fetched on demand by key).
+- `ComposeBar.addImagesFromFiles` reads files via `FileReader` with
+  `Promise.allSettled` (not `all`) so one unreadable file can't discard a whole
+  batch, and surfaces the underlying `DOMException.name` in the alert
+  (e.g. `NotReadableError` = file locked by antivirus / in use, `NotFoundError`
+  = a OneDrive "files on-demand" entry not downloaded locally). Reads can also
+  be blocked by a browser extension injecting a content script into the page.
+  The opaque "Failed to read image" message that hid all of this was issue #228.
 - `resumeLesson` re-hydrates `imageKeys` → data URLs for rendering via
   `hydrateMessageImages`. Legacy messages that still embed `imageDataUrls`
   directly render unchanged.


### PR DESCRIPTION
Closes #228.

## Problem
Pilot user (Windows 11 / Chrome) hit **"Failed to read image. Please try again."** on every image paste *and* upload in the WordPress 6 lesson. The message was a dead end:

- The `catch` block discarded the underlying error entirely.
- `Promise.all` over the per-file `FileReader` reads meant a single unreadable file failed the **whole** batch.

The user's console (shared on the issue) shows a Chrome extension injecting a `content-scripts/record…` script into the page and failing its `chrome.runtime` messaging channel — the likely culprit interfering with clipboard/file reads for that user. (Also a benign-looking `401 /v1/sync`, consistent with the normal access-token refresh cycle.)

## Change
`ComposeBar.addImagesFromFiles`:
- Reads via `Promise.allSettled` so one bad file no longer discards the others.
- Logs the real error and **surfaces its `DOMException.name`** in the alert, so a screenshot is self-diagnosing:
  - `NotReadableError` → file locked by antivirus / in use
  - `NotFoundError` → OneDrive "files on-demand" entry not downloaded locally
  - `SecurityError` / extension interference, etc.

This doesn't fix a misbehaving browser extension, but it turns an opaque dead-end into an actionable message for any future report, and makes the upload/paste path resilient to single-file failures.

## Testing
- `cd client && npm test` → 112 pass
- `eslint` clean on the changed file
- Docs updated (ARCHITECTURE → Image & conversation persistence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)