### PR TITLE
Stop profile-update agents truncating on unbounded bookkeeping arrays

### DIFF
--- a/client/js/orchestrator.js
+++ b/client/js/orchestrator.js
@@ -176,11 +176,25 @@ export async function initializeLessonKB(lesson, profileSummary) {
   return callWithValidation(callAgent, validateLessonKB);
 }
 
+// The profile-update agents only revise the "soft" fields (name, goal,
+// strengths, weaknesses, preferences, summary). `masteredLessons`/
+// `activeLessons` are system-managed bookkeeping arrays that grow without
+// bound as a learner progresses; `mergeProfile` always reunions them from the
+// stored profile, so the agent's copy is discarded anyway. Round-tripping them
+// through the model wasted input tokens and — worse — inflated the agent's JSON
+// output until it overran `max_tokens` and came back truncated/unparseable
+// (issue #228 console: "max_tokens reached" → "Failed to parse agent JSON").
+// Strip them before the call so the agent's output stays small and bounded.
+function profileForAgent(profile) {
+  const { masteredLessons: _m, activeLessons: _a, ...rest } = profile || {};
+  return rest;
+}
+
 // -- Learner Profile Owner (LLM — deep update on lesson completion) -----------
 
 export async function updateProfileOnCompletion(fullProfile, lessonKB, lessonName, lessonId, activitiesCompleted) {
   const systemPrompt = await loadPrompt('learner-profile-owner');
-  const userContent = JSON.stringify({ currentProfile: fullProfile, lessonKB, activitiesCompleted, lessonName, lessonId });
+  const userContent = JSON.stringify({ currentProfile: profileForAgent(fullProfile), lessonKB, activitiesCompleted, lessonName, lessonId });
   const { content } = await callApi({
     model: MODEL_LIGHT, systemPrompt,
     messages: [{ role: 'user', content: userContent }], maxTokens: 1024,
@@ -203,7 +217,7 @@ export function incrementalProfileUpdate(profile, lessonId) {
 export async function updateProfileFromFeedback(fullProfile, feedbackText, activityContext) {
   const systemPrompt = await loadPrompt('learner-profile-update');
   const userContent = JSON.stringify({
-    currentProfile: fullProfile, learnerFeedback: feedbackText,
+    currentProfile: profileForAgent(fullProfile), learnerFeedback: feedbackText,
     context: { lessonName: activityContext.lessonName, activityType: activityContext.activityType, activityGoal: activityContext.activityGoal, timestamp: Date.now() },
   });
   const { content } = await callApi({

--- a/client/prompts/learner-profile-owner.md
+++ b/client/prompts/learner-profile-owner.md
@@ -29,7 +29,6 @@ Every update is a rewrite, not an append. Produce the most accurate, concise ver
 
 ## Rules
 
-- Add the lessonId to `masteredLessons`
 - Update strengths to reflect what was demonstrated across all lesson objectives. Be specific.
 - Remove weaknesses contradicted by demonstrated mastery
 - Update `preferences.experienceLevel` if the lesson changes the picture
@@ -37,13 +36,14 @@ Every update is a rewrite, not an append. Produce the most accurate, concise ver
 - Set updatedAt to the current timestamp
 - Produce a compact summary (~400 characters) covering: communication style, platform, experience level, key strengths, key gaps, and support needs
 
+Do NOT include `masteredLessons` or `activeLessons` — the system records lesson completion itself; anything you put there is ignored, and echoing them only risks truncating your response.
+
 Respond with ONLY valid JSON, no markdown fencing:
 
 {
   "profile": {
     "name": "...",
     "goal": "...",
-    "masteredLessons": ["lesson-id"],
     "strengths": ["...", "..."],
     "weaknesses": ["...", "..."],
     "preferences": {},

--- a/client/prompts/learner-profile-update.md
+++ b/client/prompts/learner-profile-update.md
@@ -36,14 +36,14 @@ Update the old value — don't keep both. The latest evidence wins.
 - Set updatedAt to the current timestamp provided.
 - Produce a compact summary (~400 characters) covering: communication style, platform, experience level, key strengths, key gaps. Be specific and concise.
 
+Do NOT include `masteredLessons` or `activeLessons` — the system manages those; anything you put there is ignored, and echoing them only risks truncating your response.
+
 Respond with ONLY valid JSON, no markdown fencing:
 
 {
   "profile": {
     "name": "...",
     "goal": "...",
-    "masteredLessons": [],
-    "activeLessons": [],
     "strengths": ["...", "..."],
     "weaknesses": ["...", "..."],
     "preferences": {

--- a/client/src/lib/profileQueue.js
+++ b/client/src/lib/profileQueue.js
@@ -88,6 +88,12 @@ export function updateProfileOnCompletionInBackground(lessonKB, lesson) {
     const result = await orchestrator.updateProfileOnCompletion(
       profile, lessonKB, lesson.name, lesson.lessonId, lessonKB.activitiesCompleted
     );
+    // masteredLessons is system-managed (no longer echoed by the agent —
+    // see orchestrator.profileForAgent). Record the completion in code so
+    // mergeProfile unions it into the stored profile.
+    if (result?.profile) {
+      result.profile.masteredLessons = [...new Set([...(result.profile.masteredLessons || []), lesson.lessonId])];
+    }
     await saveProfileResult(profile, result);
   });
 }

--- a/client/tests/profileQueue.test.js
+++ b/client/tests/profileQueue.test.js
@@ -1,0 +1,69 @@
+/**
+ * Tests for mergeProfile — how an agent's profile update is merged into the
+ * stored profile. The load-bearing invariant for issue #228's profile-update
+ * fix: `masteredLessons`/`activeLessons` are system-managed and must survive
+ * even though the profile-update agents no longer echo them back (dropping the
+ * arrays from the agent's output is what keeps it under `max_tokens`).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// profileQueue imports storage/orchestrator, which touch these globals at
+// import time (mirrors courseProgressQueue.test.js).
+globalThis.localStorage = {
+  _store: {},
+  getItem(k) { return this._store[k] ?? null; },
+  setItem(k, v) { this._store[k] = v; },
+  removeItem(k) { delete this._store[k]; },
+  clear() { this._store = {}; },
+};
+globalThis.fetch = async () => ({ ok: false, status: 404 });
+
+const { mergeProfile } = await import('../src/lib/profileQueue.js');
+
+describe('mergeProfile', () => {
+  it('preserves existing bookkeeping arrays when the agent omits them', () => {
+    // The agent no longer returns masteredLessons/activeLessons (#228) — the
+    // stored values must carry through unchanged.
+    const existing = {
+      name: 'Ada', goal: 'learn',
+      masteredLessons: ['l1', 'l2'], activeLessons: ['l3'],
+      strengths: ['a'], weaknesses: ['b'], preferences: { platform: 'Mac' },
+      createdAt: 1, updatedAt: 1,
+    };
+    const returned = { strengths: ['a2'], weaknesses: ['b2'], updatedAt: 2 };
+    const merged = mergeProfile(existing, returned);
+    assert.deepEqual(merged.masteredLessons, ['l1', 'l2']);
+    assert.deepEqual(merged.activeLessons, ['l3']);
+  });
+
+  it('unions bookkeeping arrays when the agent (or code) supplies a new id', () => {
+    // The completion path injects the newly-mastered lessonId into the result.
+    const existing = { masteredLessons: ['l1'], activeLessons: [] };
+    const returned = { masteredLessons: ['l2'] };
+    const merged = mergeProfile(existing, returned);
+    assert.deepEqual(merged.masteredLessons, ['l1', 'l2']);
+  });
+
+  it('does not duplicate an id already present in both', () => {
+    const merged = mergeProfile({ masteredLessons: ['l1'] }, { masteredLessons: ['l1'] });
+    assert.deepEqual(merged.masteredLessons, ['l1']);
+  });
+
+  it('takes returned strengths/weaknesses when non-empty, else keeps existing', () => {
+    const existing = { strengths: ['old'], weaknesses: ['oldw'] };
+    assert.deepEqual(mergeProfile(existing, { strengths: ['new'] }).strengths, ['new']);
+    assert.deepEqual(mergeProfile(existing, { strengths: [] }).strengths, ['old']);
+    assert.deepEqual(mergeProfile(existing, {}).weaknesses, ['oldw']);
+  });
+
+  it('merges preferences and only overwrites name/goal when truthy', () => {
+    const existing = { name: 'Ada', goal: 'g1', preferences: { platform: 'Mac', experienceLevel: 'beginner' } };
+    const merged = mergeProfile(existing, { name: '', goal: 'g2', preferences: { platform: 'Windows' } });
+    assert.equal(merged.name, 'Ada');            // empty string does not clobber
+    assert.equal(merged.goal, 'g2');
+    assert.equal(merged.preferences.platform, 'Windows');
+    assert.equal(merged.preferences.experienceLevel, 'beginner'); // preserved
+  });
+});

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,8 +35,8 @@ it, and its purpose:
 - **lesson-extractor** — Reads: conversation text only. Extracts lesson markdown from creation chat.
 - **knowledge-base-editor** — Reads: program KB. Helps admins create/edit the KB via conversation.
 - **knowledge-base-extractor** — Reads: existing KB + conversation. Merges changes into updated KB markdown. **Summarizes, doesn't transcribe** — it produces a concise reference (a few KB), because the full KB is re-appended to every coach turn and an unbounded KB overflows the context window (and silently truncates against the extractor's own `maxTokens`). The editor (`AdminCustomizer`/`AdminKBSetup`) windows live turns to the last 15, like the lesson creator.
-- **learner-profile-owner** — Reads: learner profile, lesson KB. Full profile update on lesson completion.
-- **learner-profile-update** — Reads: learner profile, activity context. Incremental profile updates during lessons.
+- **learner-profile-owner** — Reads: learner profile, lesson KB. Full profile update on lesson completion. Only revises the "soft" fields (name, goal, strengths, weaknesses, preferences, summary); `masteredLessons`/`activeLessons` are **stripped from its input and not requested in its output** — they are system-managed bookkeeping arrays that grow without bound, and `mergeProfile` reunions them from the stored profile. The completion path records the just-mastered `lessonId` in code (`profileQueue.js`). Echoing those arrays used to inflate the agent's JSON past `maxTokens`, truncating it into an unparseable response (#228).
+- **learner-profile-update** — Reads: learner profile (minus the bookkeeping arrays), activity context. Incremental profile updates during lessons; same soft-fields-only contract as `learner-profile-owner`.
 - **course-progress-update** — Reads: prior course summary, just-completed lesson KB, course lesson list. Maintains the per-learner `courseProgress:<courseId>` note injected into the coach as `course.progress`.
 
 Context appended at runtime (`client/js/orchestrator.js`):


### PR DESCRIPTION
Closes the `max_tokens` / profile-parse failures seen in the #228 console session:

```
[plato] Response truncated — max_tokens reached. Output may be incomplete.
[plato] Profile update failed: Failed to parse agent JSON response.
```

## Root cause
The `learner-profile-update` and `learner-profile-owner` agents are sent the learner's **full profile** and asked to return it rewritten — including `masteredLessons` and `activeLessons`. Those arrays grow without bound as a learner completes lessons. `mergeProfile` already reunions them from the stored profile (so the agent's echoed copies were **discarded anyway**), but echoing them inflated the agent's JSON output until it blew past `max_tokens` and came back truncated → `JSON.parse` failed → the profile silently stopped updating.

## Fix
- `orchestrator.profileForAgent()` strips `masteredLessons`/`activeLessons` from the profile sent to **both** agents — their output now only covers the bounded "soft" fields (name, goal, strengths ≤5, weaknesses ≤5, preferences, ~400-char summary).
- Both prompt schemas drop those arrays and explicitly instruct the agent not to emit them.
- `masteredLessons` is now recorded **in code** on completion (`profileQueue.js`), since the agent no longer manages it; `activeLessons` was already code-managed.

## Testing
- New `client/tests/profileQueue.test.js` covers `mergeProfile` (arrays survive when the agent omits them; union on a new id; no duplicates; strengths/weaknesses/preferences/name merge rules).
- `cd client && npm test` → 117 pass
- `eslint` clean
- Docs: ARCHITECTURE AI-agents section documents the soft-fields-only contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)