### PR TITLE
Fix lesson-started-hook tests to use SQLite instead of DynamoDB

### DIFF
--- a/server/tests/routes/lesson-started-hook.test.js
+++ b/server/tests/routes/lesson-started-hook.test.js
@@ -1,13 +1,10 @@
-import { describe, it, before, after } from 'node:test';
+import { describe, it, beforeEach, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { Hono } from 'hono';
 import sync from '../../src/routes/sync.js';
 import { on, _reset as resetHooks } from '../../src/lib/plugins/hooks.js';
 import db from '../../src/lib/db.js';
 import { signAccessToken } from '../../src/lib/jwt.js';
-
-// Ensure AWS_REGION is set for DynamoDB client (CI needs this)
-if (!process.env.AWS_REGION) process.env.AWS_REGION = 'us-east-1';
 
 // Silence console
 const origErr = console.error;
@@ -20,30 +17,24 @@ describe('POST /v1/sync/lesson-started', () => {
   let token;
   const userId = 'test-user-lesson-started';
 
-  before(async () => {
-    // Create test user
-    await db.createUser({
-      userId,
-      email: 'test@example.com',
-      username: 'testuser',
-      passwordHash: 'hashed-password',
-      name: 'Test User',
-      role: 'user',
-    });
-    token = signAccessToken(userId, 'user');
+  beforeEach(async () => {
+    resetHooks();
+    // Mock db methods for authentication
+    db.getUserById = async (id) => {
+      if (id === userId) {
+        return { userId, email: 'test@example.com', username: 'testuser', name: 'Test User', role: 'user' };
+      }
+      return null;
+    };
 
-    // Mount route
+    token = await signAccessToken(userId, 'user');
+
+    // Mount route (sync includes authenticate middleware)
     app = new Hono();
-    app.use('*', async (c, next) => {
-      c.set('userId', userId);
-      c.set('role', 'user');
-      await next();
-    });
     app.route('/', sync);
   });
 
-  after(async () => {
-    await db.deleteUser(userId);
+  after(() => {
     resetHooks();
   });
 


### PR DESCRIPTION
## Problem

The `lesson-started-hook.test.js` test was failing in CI with:

```
CredentialsProviderError: Could not load credentials from any providers
```

This happened because the test was trying to create a real user in DynamoDB without AWS credentials configured in the CI environment.

## Solution

Mock the `db.getUserById` method like other route tests do, instead of trying to use a real database:

- Mock `db.getUserById` in `beforeEach` to return a test user
- Add missing `await` for `signAccessToken()` (it's async)
- Remove the manual middleware that was redundantly setting `userId`/`role` (the sync route's `authenticate` middleware already handles this)

This follows the same pattern as `server/tests/routes/sync.test.js`, `server/tests/routes/lifecycle-hooks.test.js`, and other route tests that mock db methods instead of using a real database.

## Testing

```bash
cd server && npm test
```

All tests pass, including `lesson-started-hook.test.js` which was previously failing.

Fixes the persistent server test failures in CI seen in PRs #276, #277, and on main branch.