### PR TITLE
Pass coachDirective to wordpress-info plugin for better keyword detection

### DIFF
--- a/client/src/lib/lessonEngine.js
+++ b/client/src/lib/lessonEngine.js
@@ -178,6 +178,7 @@ export async function startLesson(lessonId, lesson, onStream, onProgress) {
           markdown: lesson.markdown,
           exemplar: lesson.exemplar,
           learningObjectives: lesson.learningObjectives,
+          coachDirective: lesson.coachDirective,
         },
         lessonKB,
       }),

--- a/plugins/wordpress-info/CLAUDE.md
+++ b/plugins/wordpress-info/CLAUDE.md
@@ -11,7 +11,7 @@ related lessons at start time and enriches them with up-to-date context from:
 Three-agent pipeline triggered by the `lessonStarted` hook:
 
 1. **Planner agent** (`prompts/wordpress-info-planner.md`) — takes the lesson
-   exemplar + objectives and decides:
+   exemplar, objectives, and optional coach directive and decides:
    - Is this WordPress-related? (keyword detection)
    - What queries to run?
    - Which sources to check per query?
@@ -23,9 +23,10 @@ Three-agent pipeline triggered by the `lessonStarted` hook:
    or API errors never block.
 
 3. **Synthesizer agent** (`prompts/wordpress-info-synthesizer.md`) — takes the
-   raw results and lesson context, synthesizes a concise (~300 word) summary
-   highlighting: relevant APIs, best practices, common pitfalls, version-specific
-   notes. Returns `{ context: string, reasoning: string }`.
+   raw results and lesson context (exemplar, objectives, coach directive),
+   synthesizes a concise (~300 word) summary highlighting: relevant APIs,
+   best practices, common pitfalls, version-specific notes. Returns
+   `{ context: string, reasoning: string }`.
 
 The final enrichment data (`{ context, sources, reasoning, pluginId, label }`)
 is returned from the `lessonStarted` hook handler, stored on `lessonKB.enrichments`,

--- a/plugins/wordpress-info/prompts/wordpress-info-planner.md
+++ b/plugins/wordpress-info/prompts/wordpress-info-planner.md
@@ -30,6 +30,7 @@ You are the WordPress Info Planner. Your job is to analyze a plato lesson and de
 You will receive:
 - **exemplar**: The target skill or understanding the lesson aims for
 - **learningObjectives**: Specific measurable objectives (array of strings)
+- **coachDirective** (optional): Author-supplied runtime instructions for the coach (e.g., "reference the learner's portfolio", "point learners to the Block Editor Handbook")
 - **keywords**: List of WordPress-related terms we recognize
 
 ## Output

--- a/plugins/wordpress-info/server/index.js
+++ b/plugins/wordpress-info/server/index.js
@@ -126,6 +126,7 @@ async function onLessonStarted({ userId, lessonId, lesson, lessonKB, onProgress 
 **Learning Objectives:**
 ${(lesson.learningObjectives || []).map(obj => `- ${obj}`).join('\n')}
 
+${lesson.coachDirective ? `**Coach Directive:**\n${lesson.coachDirective}\n` : ''}
 **WordPress Keywords:** ${KEYWORDS.join(', ')}
 
 Analyze this lesson and decide whether to enrich it with WordPress documentation.
@@ -174,6 +175,7 @@ Analyze this lesson and decide whether to enrich it with WordPress documentation
 **Learning Objectives:**
 ${(lesson.learningObjectives || []).map(obj => `- ${obj}`).join('\n')}
 
+${lesson.coachDirective ? `**Coach Directive:**\n${lesson.coachDirective}\n` : ''}
 **Query Results:**
 
 ${resultsText}

--- a/server/src/routes/sync.js
+++ b/server/src/routes/sync.js
@@ -292,7 +292,7 @@ sync.delete('/v1/sync/:dataKey', async (c) => {
  *
  * Request body:
  *   - lessonId: string (required)
- *   - lesson: { name, markdown, exemplar, learningObjectives } (required)
+ *   - lesson: { name, markdown, exemplar, learningObjectives, coachDirective? } (required)
  *   - lessonKB: object (required)
  *
  * Response:
@@ -358,6 +358,7 @@ sync.post('/v1/sync/lesson-started', async (c) => {
       markdown: lesson.markdown,
       exemplar: lesson.exemplar,
       learningObjectives: lesson.learningObjectives,
+      coachDirective: lesson.coachDirective,
     },
     lessonKB
   });

--- a/server/tests/routes/sync.test.js
+++ b/server/tests/routes/sync.test.js
@@ -458,4 +458,23 @@ describe('POST /v1/sync/lesson-started', () => {
     });
     assert.equal(res.status, 403, 'must reject write when asUserId is present');
   });
+
+  it('accepts optional coachDirective field', async () => {
+    const app = new Hono();
+    app.route('/', sync);
+    const res = await authedReq(app, 'POST', '/v1/sync/lesson-started', {
+      lessonId: 'test-lesson',
+      lesson: {
+        name: 'Test',
+        markdown: '# Test',
+        exemplar: 'Learn WordPress',
+        learningObjectives: ['Understand hooks'],
+        coachDirective: 'Point learners to the Block Editor Handbook',
+      },
+      lessonKB: { status: 'active' },
+    });
+    assert.equal(res.status, 200);
+    const data = await res.json();
+    assert.ok(Array.isArray(data.enrichments), 'enrichments must be an array');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the wordpress-info plugin not enriching WordPress lessons when WordPress-specific context is in the Coach Directive section rather than the learning objectives.

## Problem

The wordpress-info plugin's planner agent was only receiving:
- Lesson exemplar
- Learning objectives

But **not** the optional Coach Directive section, which often contains WordPress-specific guidance like:
- URLs to Block Editor Handbook
- References to wordpress.org
- Portfolio examples with WordPress content

For "WordPress 6 - Content Development" and similar lessons, the planner couldn't detect WordPress context because it lived in the directive.

## Solution

Pass `lesson.coachDirective` through the entire enrichment pipeline:

1. **Client** (`lessonEngine.js`) — Include `coachDirective` in `/v1/sync/lesson-started` payload
2. **Server** (`routes/sync.js`) — Pass `coachDirective` to `lessonStarted` hook
3. **Plugin** (`wordpress-info/server/index.js`) — Include coach directive in both planner and synthesizer context
4. **Docs** — Update API comment, plugin CLAUDE.md, planner prompt
5. **Tests** — Add test verifying optional `coachDirective` field accepted

## Test Plan

- ✅ All existing tests pass (350 tests)
- ✅ New test verifies `coachDirective` accepted by `/v1/sync/lesson-started`
- Manual: Start "WordPress 6 - Content Development" on learn.ai-leaders.org and verify enrichment runs

## Notes

- The field is optional—lessons without a coach directive continue to work
- Planner and synthesizer both receive the directive for better keyword detection and more targeted enrichment
- Follows existing fail-open semantics—plugin errors never block lesson start

🤖 Generated with [Claude Code](https://claude.com/claude-code)