### PR TITLE
Add migration note for client/data removal in deploy workflows

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -70,6 +70,15 @@ The `Stage` parameter controls DynamoDB table name prefixes and SSM parameter pa
 
 For production deployments, we recommend automating deploys from a **private fork** via GitHub Actions. This keeps your AWS credentials and deploy config out of the public repo. The flow here uses `repository_dispatch`: pushing to the public repo fires a dispatch event to the private fork, which runs the actual deploy. No manual pushing to the deploy remote, and the deploy workflows never need to exist in the public repo.
 
+> **⚠️ Migration note (June 2026)**: If your private fork's `.github/workflows/deploy.yml` copies `client/data`, remove that reference. PR #288 deleted `client/data/` — only `client/prompts` is needed now. Update the `cp` command from:
+> ```bash
+> cp -r client/prompts client/data server/.aws-sam/build/.../client-content/
+> ```
+> to:
+> ```bash
+> cp -r client/prompts server/.aws-sam/build/.../client-content/
+> ```
+
 **Create a private fork:**
 
 ```bash


### PR DESCRIPTION
Adds a migration note to docs/DEPLOY.md alerting users with private forks that their deploy workflows may need updating after PR #288 removed `client/data/`.

## Context

PR #288 deleted `client/data/` and updated the manual deploy instructions in DEPLOY.md, but private forks with custom `.github/workflows/deploy.yml` files still had the old `cp` command referencing it.

This caused a deploy failure in UIC-OSF/learn.ai-leaders.org:
```
cp: cannot stat 'client/data': No such file or directory
```

## Changes

- Added prominent migration note at the top of the CI/CD section
- Shows the old vs new `cp` command
- Fixed in UIC-OSF/learn.ai-leaders.org@97b6a7e

## Impact

Low - documentation only. Helps anyone maintaining a private fork with custom deploy automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)