### PR TITLE
Fix plugin AI hang: pass ai+LLM via ctx instead of direct import

### DIFF
--- a/docs/plugins/CAPABILITIES.md
+++ b/docs/plugins/CAPABILITIES.md
@@ -84,18 +84,17 @@ Allows a plugin to enrich lessons at start time by providing additional context,
 
 **Contract:** Enrichments are informational only — they provide reference material the coach can draw on but MUST NOT override completion semantics. The coach (`applyCoachResponseToKB`) remains the single owner of progress and completion.
 
-**Calling the AI from a lessonEnrichment plugin:** Import `ai` and `LLM` from the host's `ai-provider.js`. Never hardcode model strings:
+**Calling the AI from a lessonEnrichment plugin:** Use `ctx.ai` and `ctx.LLM` injected by the host — do NOT import `ai-provider.js` directly. The host injects the already-initialized provider instance so plugins share the same Bedrock client. Importing it directly via a relative path can resolve to a different module instance in Lambda (due to symlink path differences), causing the Bedrock client to hang:
 
 ```js
-import ai, { LLM } from '../../../server/src/lib/ai-provider.js';
-
-const result = await ai.invoke(LLM, {
-  max_tokens: 1024,
-  messages: [{ role: 'user', content: prompt }],
-});
+async function onLessonStarted(payload, ctx) {
+  const { ai, LLM } = ctx;
+  const result = await ai.invoke(LLM, {
+    max_tokens: 1024,
+    messages: [{ role: 'user', content: prompt }],
+  });
+}
 ```
-
-This works with both Bedrock (production) and the Anthropic API (local dev) — the host selects the provider based on environment variables.
 
 Phase 1 (available).
 

--- a/plugins/wordpress-info/server/index.js
+++ b/plugins/wordpress-info/server/index.js
@@ -12,7 +12,6 @@
 
 import { KEYWORDS, SOURCES } from './sources.js';
 import { executeQueries } from './query-executor.js';
-import ai, { LLM } from '../../../server/src/lib/ai-provider.js';
 
 const PLANNER_SCHEMA = {
   type: 'object',
@@ -64,11 +63,10 @@ async function loadPrompt(name) {
 /**
  * Call an agent with structured output. Returns the parsed JSON object.
  */
-async function callAgentWithSchema(promptName, context, schema, model) {
+async function callAgentWithSchema(promptName, context, schema, ai, model) {
   const prompt = await loadPrompt(promptName);
   const fullPrompt = `${prompt}\n\n${context}`;
 
-  // Call AI provider directly (server-side)
   const response = await ai.invoke(model, {
     max_tokens: 2048,
     messages: [{ role: 'user', content: fullPrompt }],
@@ -111,7 +109,8 @@ async function callAgentWithSchema(promptName, context, schema, model) {
  * lessonStarted hook handler.
  * The payload includes an optional onProgress callback for reporting step status.
  */
-async function onLessonStarted({ userId, lessonId, lesson, lessonKB, onProgress }) {
+async function onLessonStarted({ userId, lessonId, lesson, lessonKB, onProgress }, ctx) {
+  const { ai, LLM } = ctx;
   const reportProgress = (stepId, status) => {
     if (onProgress) onProgress('wordpress-info', stepId, status);
   };
@@ -131,7 +130,7 @@ ${lesson.coachDirective ? `**Coach Directive:**\n${lesson.coachDirective}\n` : '
 Analyze this lesson and decide whether to enrich it with WordPress documentation.
 `;
 
-    const plan = await callAgentWithSchema('wordpress-info-planner', plannerContext, PLANNER_SCHEMA, LLM);
+    const plan = await callAgentWithSchema('wordpress-info-planner', plannerContext, PLANNER_SCHEMA, ai, LLM);
 
     if (!plan || !plan.shouldEnrich || !plan.queries || !plan.queries.length) {
       // Not WordPress-related — mark scan complete, skip remaining steps
@@ -182,7 +181,7 @@ ${resultsText}
 Synthesize a concise, lesson-specific context note (~300 words).
 `;
 
-    const synthesis = await callAgentWithSchema('wordpress-info-synthesizer', synthesizerContext, SYNTHESIZER_SCHEMA, LLM);
+    const synthesis = await callAgentWithSchema('wordpress-info-synthesizer', synthesizerContext, SYNTHESIZER_SCHEMA, ai, LLM);
     if (!synthesis || !synthesis.context) {
       reportProgress('synthesize-context', 'failed');
       return null;

--- a/server/src/lib/plugins/registry.js
+++ b/server/src/lib/plugins/registry.js
@@ -97,8 +97,8 @@ function loadManifest(manifestPath, expectedId) {
   return validateManifest(raw, { expectedId });
 }
 
-/** Build a context object for hooks/lifecycle invocations. */
-function buildContext(id, settings) {
+/** Build a context object for hooks/lifecycle invocations. Exported for tests. */
+export function buildContext(id, settings) {
   return {
     pluginId: id,
     logger: createPluginLogger(id),

--- a/server/src/lib/plugins/registry.js
+++ b/server/src/lib/plugins/registry.js
@@ -20,6 +20,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import db from '../db.js';
 import { logger } from '../logger.js';
+import ai, { LLM } from '../ai-provider.js';
 import { validateManifest } from './manifest.js';
 import { satisfies, PLUGIN_API_VERSION } from './version.js';
 import { on as hookOn, emit as hookEmit } from './hooks.js';
@@ -107,6 +108,8 @@ function buildContext(id, settings) {
       await pluginRegistry.updateSettings(id, next);
     },
     emit: (event, payload) => hookEmit(event, payload),
+    ai,
+    LLM,
   };
 }
 

--- a/server/tests/lib/plugins/registry.test.js
+++ b/server/tests/lib/plugins/registry.test.js
@@ -1,43 +1,22 @@
-import { describe, it, beforeEach } from 'node:test';
+import { describe, it, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { on, _reset as resetHooks } from '../../../src/lib/plugins/hooks.js';
+import { buildContext } from '../../../src/lib/plugins/registry.js';
 import ai, { LLM } from '../../../src/lib/ai-provider.js';
 
-// Silence console noise from registry boot
 const origWarn = console.warn;
 console.warn = () => {};
+after(() => { console.warn = origWarn; });
 
-describe('plugin context — ctx.ai and ctx.LLM', () => {
-  beforeEach(() => resetHooks());
+describe('buildContext — ctx.ai and ctx.LLM', () => {
+  it('provides ctx.ai as the host ai provider instance', () => {
+    const ctx = buildContext('test-plugin', {});
+    assert.strictEqual(ctx.ai, ai, 'ctx.ai must be the same instance the host uses');
+    assert.equal(typeof ctx.ai.invoke, 'function', 'ctx.ai must expose invoke()');
+  });
 
-  it('hook handlers receive ctx.ai (the host ai provider instance)', async () => {
-    // Simulate what the registry's subscribeHooks does: wrap a hook fn so it
-    // receives (payload, ctx). We test the ctx.ai contract directly by
-    // registering a handler that captures ctx and checking the reference.
-    let capturedCtx = null;
-
-    // Build a minimal ctx matching what buildContext() returns, including ai/LLM
-    const ctx = {
-      pluginId: 'test',
-      logger: { log: () => {}, warn: () => {}, error: () => {} },
-      db: {},
-      settings: {},
-      setSettings: async () => {},
-      emit: () => {},
-      ai,
-      LLM,
-    };
-
-    const handler = (payload, c) => { capturedCtx = c; return null; };
-
-    // Simulate registry's subscribeHooks wrapper: calls fn(payload, ctx)
-    on('lessonStarted', (payload) => handler(payload, ctx));
-    const { emit } = await import('../../../src/lib/plugins/hooks.js');
-    await emit('lessonStarted', { lessonId: 'x' });
-
-    assert.ok(capturedCtx, 'ctx must be passed to hook handler');
-    assert.strictEqual(capturedCtx.ai, ai, 'ctx.ai must be the same ai instance as the host uses');
-    assert.strictEqual(capturedCtx.LLM, LLM, 'ctx.LLM must match the host LLM constant');
-    assert.equal(typeof capturedCtx.ai.invoke, 'function', 'ctx.ai must expose an invoke() method');
+  it('provides ctx.LLM matching the host LLM constant', () => {
+    const ctx = buildContext('test-plugin', {});
+    assert.strictEqual(ctx.LLM, LLM, 'ctx.LLM must match the host LLM constant');
+    assert.equal(typeof ctx.LLM, 'string', 'ctx.LLM must be a string model identifier');
   });
 });

--- a/server/tests/lib/plugins/registry.test.js
+++ b/server/tests/lib/plugins/registry.test.js
@@ -1,0 +1,43 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { on, _reset as resetHooks } from '../../../src/lib/plugins/hooks.js';
+import ai, { LLM } from '../../../src/lib/ai-provider.js';
+
+// Silence console noise from registry boot
+const origWarn = console.warn;
+console.warn = () => {};
+
+describe('plugin context — ctx.ai and ctx.LLM', () => {
+  beforeEach(() => resetHooks());
+
+  it('hook handlers receive ctx.ai (the host ai provider instance)', async () => {
+    // Simulate what the registry's subscribeHooks does: wrap a hook fn so it
+    // receives (payload, ctx). We test the ctx.ai contract directly by
+    // registering a handler that captures ctx and checking the reference.
+    let capturedCtx = null;
+
+    // Build a minimal ctx matching what buildContext() returns, including ai/LLM
+    const ctx = {
+      pluginId: 'test',
+      logger: { log: () => {}, warn: () => {}, error: () => {} },
+      db: {},
+      settings: {},
+      setSettings: async () => {},
+      emit: () => {},
+      ai,
+      LLM,
+    };
+
+    const handler = (payload, c) => { capturedCtx = c; return null; };
+
+    // Simulate registry's subscribeHooks wrapper: calls fn(payload, ctx)
+    on('lessonStarted', (payload) => handler(payload, ctx));
+    const { emit } = await import('../../../src/lib/plugins/hooks.js');
+    await emit('lessonStarted', { lessonId: 'x' });
+
+    assert.ok(capturedCtx, 'ctx must be passed to hook handler');
+    assert.strictEqual(capturedCtx.ai, ai, 'ctx.ai must be the same ai instance as the host uses');
+    assert.strictEqual(capturedCtx.LLM, LLM, 'ctx.LLM must match the host LLM constant');
+    assert.equal(typeof capturedCtx.ai.invoke, 'function', 'ctx.ai must expose an invoke() method');
+  });
+});


### PR DESCRIPTION
## Root Cause

The wordpress-info plugin imported `ai-provider.js` directly via a relative path through the symlink the deploy workflow creates (`server/src -> ../src`). This caused the same file to resolve to two different module URLs:

- Server: `/var/task/src/lib/ai-provider.js`
- Plugin: `/var/task/server/src/lib/ai-provider.js` (via symlink)

ES module caching keys on the resolved URL, so the plugin received a **separate, uninitialized `BedrockRuntimeClient`** from the one the server already set up. That uninitialized client hung on every call with no error — triggering the 30s enrichment timeout every time.

CloudWatch evidence: every `lesson-started` request ran for exactly 30,010ms with zero application logs, then returned `[]`. The `lesson_enrichment_timeout` error code never appeared because the hang happened inside the plugin before any logging.

## Fix

Expose `ai` and `LLM` on the plugin context (`ctx.ai`, `ctx.LLM`) from `registry.js`, which already imports `ai-provider.js` via the canonical server path. The plugin removes its direct import and uses `ctx.ai`/`ctx.LLM` instead. All plugins now share the same initialized Bedrock client.

## Changes

- `server/src/lib/plugins/registry.js` — import `ai` + `LLM` from ai-provider, add to `buildContext()`
- `plugins/wordpress-info/server/index.js` — remove direct ai-provider import, use `ctx.ai`/`ctx.LLM`
- `docs/plugins/CAPABILITIES.md` — update pattern to use `ctx.ai`/`ctx.LLM`, warn against direct import

## Test Plan

After deploy: reset WordPress 6 lesson, start fresh, verify enrichment runs (CloudWatch should show plugin execution and non-30s request duration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)