### PR TITLE
Add AI Leaders Finalists announcement banner

### DIFF
--- a/client/src/components/AnnouncementBanner.jsx
+++ b/client/src/components/AnnouncementBanner.jsx
@@ -1,0 +1,27 @@
+import { Button } from '@/components/ui/button';
+
+export default function AnnouncementBanner() {
+  return (
+    <div className="w-full bg-purple-700 border-b border-purple-600" role="banner">
+      <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-center gap-4 flex-wrap">
+        <p className="text-white font-medium text-sm sm:text-base">
+          Meet the AI Leaders Finalists
+        </p>
+        <Button
+          asChild
+          size="sm"
+          variant="secondary"
+          className="bg-white text-purple-700 hover:bg-purple-50"
+        >
+          <a
+            href="https://aileaderswp.blog/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            View Portfolios
+          </a>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/ForgotPassword.jsx
+++ b/client/src/pages/ForgotPassword.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import usePublicBranding from '../hooks/usePublicBranding.js';
+import AnnouncementBanner from '../components/AnnouncementBanner.jsx';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -40,8 +41,10 @@ export default function ForgotPassword() {
   if (!branding) return null;
 
   return (
-    <main className="min-h-dvh flex flex-col items-center justify-center p-4" style={{ backgroundColor: branding.primary }}>
-      {branding.logo ? (<img src={branding.logo} alt={branding.classroomName} className="h-16 w-16 mb-6 rounded-lg object-contain" />) : (<h1 className="text-2xl font-bold text-white mb-6">{branding.classroomName}</h1>)}
+    <>
+      <AnnouncementBanner />
+      <main className="min-h-dvh flex flex-col items-center justify-center p-4" style={{ backgroundColor: branding.primary }}>
+        {branding.logo ? (<img src={branding.logo} alt={branding.classroomName} className="h-16 w-16 mb-6 rounded-lg object-contain" />) : (<h1 className="text-2xl font-bold text-white mb-6">{branding.classroomName}</h1>)}
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle className="text-2xl">Reset password</CardTitle>
@@ -80,9 +83,10 @@ export default function ForgotPassword() {
           </Button>
         </CardFooter>
       </Card>
-      <p className="mt-4 text-xs text-white/60">
-        Powered by <a href="https://github.com/1111philo/plato" target="_blank" rel="noopener noreferrer" className="underline hover:text-white/80">plato</a>.
-      </p>
-    </main>
+        <p className="mt-4 text-xs text-white/60">
+          Powered by <a href="https://github.com/1111philo/plato" target="_blank" rel="noopener noreferrer" className="underline hover:text-white/80">plato</a>.
+        </p>
+      </main>
+    </>
   );
 }

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext.jsx';
 import usePublicBranding from '../hooks/usePublicBranding.js';
 import PasswordField from '../components/PasswordField.jsx';
+import AnnouncementBanner from '../components/AnnouncementBanner.jsx';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -42,12 +43,14 @@ export default function Login() {
   const { primary: headerBg, logo, classroomName } = branding;
 
   return (
-    <main className="min-h-dvh flex flex-col items-center justify-center p-4" style={{ backgroundColor: headerBg }}>
-      {logo ? (
-        <img src={logo} alt={classroomName} className="h-16 w-16 mb-6 rounded-lg object-contain" />
-      ) : (
-        <h1 className="text-2xl font-bold text-white mb-6">{classroomName}</h1>
-      )}
+    <>
+      <AnnouncementBanner />
+      <main className="min-h-dvh flex flex-col items-center justify-center p-4" style={{ backgroundColor: headerBg }}>
+        {logo ? (
+          <img src={logo} alt={classroomName} className="h-16 w-16 mb-6 rounded-lg object-contain" />
+        ) : (
+          <h1 className="text-2xl font-bold text-white mb-6">{classroomName}</h1>
+        )}
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle className="text-2xl">Sign in</CardTitle>
@@ -78,9 +81,10 @@ export default function Login() {
           <Button variant="link" onClick={() => navigate('/forgot-password')}>Forgot password?</Button>
         </CardFooter>
       </Card>
-      <p className="mt-4 text-xs text-white/60">
-        Powered by <a href="https://github.com/1111philo/plato" target="_blank" rel="noopener noreferrer" className="underline hover:text-white/80">plato</a>.
-      </p>
-    </main>
+        <p className="mt-4 text-xs text-white/60">
+          Powered by <a href="https://github.com/1111philo/plato" target="_blank" rel="noopener noreferrer" className="underline hover:text-white/80">plato</a>.
+        </p>
+      </main>
+    </>
   );
 }

--- a/client/src/pages/ResetPassword.jsx
+++ b/client/src/pages/ResetPassword.jsx
@@ -2,6 +2,7 @@ import { useState, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import usePublicBranding from '../hooks/usePublicBranding.js';
 import PasswordField from '../components/PasswordField.jsx';
+import AnnouncementBanner from '../components/AnnouncementBanner.jsx';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import {
@@ -53,8 +54,10 @@ export default function ResetPassword() {
   if (!branding) return null;
 
   return (
-    <main className="min-h-dvh flex flex-col items-center justify-center p-4" style={{ backgroundColor: branding.primary }}>
-      {branding.logo ? (<img src={branding.logo} alt={branding.classroomName} className="h-16 w-16 mb-6 rounded-lg object-contain" />) : (<h1 className="text-2xl font-bold text-white mb-6">{branding.classroomName}</h1>)}
+    <>
+      <AnnouncementBanner />
+      <main className="min-h-dvh flex flex-col items-center justify-center p-4" style={{ backgroundColor: branding.primary }}>
+        {branding.logo ? (<img src={branding.logo} alt={branding.classroomName} className="h-16 w-16 mb-6 rounded-lg object-contain" />) : (<h1 className="text-2xl font-bold text-white mb-6">{branding.classroomName}</h1>)}
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle className="text-2xl">Set new password</CardTitle>
@@ -96,9 +99,10 @@ export default function ResetPassword() {
           </Button>
         </CardContent>
       </Card>
-      <p className="mt-4 text-xs text-white/60">
-        Powered by <a href="https://github.com/1111philo/plato" target="_blank" rel="noopener noreferrer" className="underline hover:text-white/80">plato</a>.
-      </p>
-    </main>
+        <p className="mt-4 text-xs text-white/60">
+          Powered by <a href="https://github.com/1111philo/plato" target="_blank" rel="noopener noreferrer" className="underline hover:text-white/80">plato</a>.
+        </p>
+      </main>
+    </>
   );
 }

--- a/client/src/pages/Signup.jsx
+++ b/client/src/pages/Signup.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext.jsx';
 import usePublicBranding from '../hooks/usePublicBranding.js';
 import PasswordField from '../components/PasswordField.jsx';
+import AnnouncementBanner from '../components/AnnouncementBanner.jsx';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -75,8 +76,10 @@ export default function Signup() {
   if (!branding) return null;
 
   return (
-    <main className="min-h-dvh flex flex-col items-center justify-start py-12 p-4" style={{ backgroundColor: branding.primary }}>
-      {branding.logo ? (<img src={branding.logo} alt={branding.classroomName} className="h-16 w-16 mb-6 rounded-lg object-contain" />) : (<h1 className="text-2xl font-bold text-white mb-6">{branding.classroomName}</h1>)}
+    <>
+      <AnnouncementBanner />
+      <main className="min-h-dvh flex flex-col items-center justify-start py-12 p-4" style={{ backgroundColor: branding.primary }}>
+        {branding.logo ? (<img src={branding.logo} alt={branding.classroomName} className="h-16 w-16 mb-6 rounded-lg object-contain" />) : (<h1 className="text-2xl font-bold text-white mb-6">{branding.classroomName}</h1>)}
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle className="text-2xl">Create your account</CardTitle>
@@ -159,9 +162,10 @@ export default function Signup() {
           </Button>
         </CardFooter>
       </Card>
-      <p className="mt-4 text-xs text-white/60">
-        Powered by <a href="https://github.com/1111philo/plato" target="_blank" rel="noopener noreferrer" className="underline hover:text-white/80">plato</a>.
-      </p>
-    </main>
+        <p className="mt-4 text-xs text-white/60">
+          Powered by <a href="https://github.com/1111philo/plato" target="_blank" rel="noopener noreferrer" className="underline hover:text-white/80">plato</a>.
+        </p>
+      </main>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Created reusable `AnnouncementBanner` component with purple background
- Added banner to all public auth pages (Login, Signup, ForgotPassword, ResetPassword)
- Banner displays "Meet the AI Leaders Finalists" with "View Portfolios" button linking to https://aileaderswp.blog/
- Uses consistent styling patterns from existing components (Button, responsive layout)

## Test plan
- [x] Verify banner appears on all public pages
- [x] Test responsive layout on mobile/desktop
- [x] Verify external link opens in new tab
- [x] Check accessibility (keyboard navigation, aria attributes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)